### PR TITLE
Linux install: advise WM/DE autostart

### DIFF
--- a/_wiki/Install/Linux.md
+++ b/_wiki/Install/Linux.md
@@ -65,6 +65,8 @@ systemctl --user daemon-reload
 systemctl --user enable opentabletdriver --now
 ```
 
+If the systemd user service does not start consistently, consider adding `otd-daemon` to your WM or DE's autostart.
+
 ---
 
 ### Gentoo {#gentoo}


### PR DESCRIPTION
On some systemd setups, the service cannot reliably start.

See OpenTabletDriver/OpenTabletDriver.Web#43