### PR TITLE
Plugins: Update filtering, style and add driver compatibility

### DIFF
--- a/_includes/filterjs.html
+++ b/_includes/filterjs.html
@@ -16,6 +16,9 @@
     let searchInput = document.getElementById('searchInput');
     let searchFilter = searchInput.value.toUpperCase();
 
+    let matchCompatible = document.getElementById('onlyMatchSpecificVersion');
+    let onlyMatchSpecificVersion = matchCompatible.checked;
+
     let container = document.getElementById('metadataList');
     let cards = container.getElementsByClassName('plugin-metadata-card');
 
@@ -25,9 +28,35 @@
       let version = card.getAttribute('data-version');
 
       let searchMatches = name.indexOf(searchFilter) >= 0;
-      let versionMatches = targetVersion == '' || targetVersion == version;
+      let versionMatches = targetVersion == '' || (onlyMatchSpecificVersion ?  version == targetVersion : isCompatible(version, targetVersion) );
 
       card.style.display = searchMatches && versionMatches ? '' : 'none';
     }
+  }
+
+  function isCompatible(pluginVersion, driverVersion) {
+    // support truth table:
+    //  plugin  /  driver
+    // 0.5.3.3 and 0.6.0.0: false
+    // 0.6.0.0 and 0.5.3.3: false
+    // 0.5.2.0 and 0.5.3.3: true
+    // 0.5.3.3 and 0.5.2.0: false
+
+    let pluginSplit = pluginVersion.split('.');
+    let driverSplit = driverVersion.split('.');
+
+    let pluginMajor = pluginSplit.slice(0, 2).join('.');
+    let driverMajor = driverSplit.slice(0, 2).join('.');
+
+    if (pluginMajor != driverMajor)
+      return false;
+
+    let pluginMinor = pluginSplit.slice(2).join('.');
+    let driverMinor = driverSplit.slice(2).join('.');
+
+    if (pluginMinor <= driverMinor)
+      return true;
+
+    return false;
   }
 </script>

--- a/_includes/filterjs.html
+++ b/_includes/filterjs.html
@@ -19,6 +19,27 @@
     let container = document.getElementById('metadataList');
     let cards = container.getElementsByClassName('plugin-metadata-card');
 
+    let versions = {};
+
+    if (targetVersion != '') {
+      for (let i = 0; i < cards.length; i++) {
+        let card = cards[i];
+        let name = card.getAttribute('data-name').toUpperCase();
+        let version = card.getAttribute('data-version');
+
+        if (!isCompatible(version, targetVersion))
+          continue;
+
+        if (name in versions) {
+          if (versions[name] < version) {
+            versions[name] = version;
+          }
+        } else {
+          versions[name] = version;
+        }
+      }
+    }
+
     for (let i = 0; i < cards.length; i++) {
       let card = cards[i];
       let name = card.getAttribute('data-name').toUpperCase();
@@ -26,8 +47,12 @@
 
       let searchMatches = name.indexOf(searchFilter) >= 0;
       let versionMatches = targetVersion == '' || isCompatible(version, targetVersion);
+      let isNewest = true;
+      if (name in versions) {
+        isNewest = versions[name] == version;
+      }
 
-      card.style.display = searchMatches && versionMatches ? '' : 'none';
+      card.style.display = searchMatches && versionMatches && isNewest ? '' : 'none';
     }
   }
 

--- a/_includes/filterjs.html
+++ b/_includes/filterjs.html
@@ -16,9 +16,6 @@
     let searchInput = document.getElementById('searchInput');
     let searchFilter = searchInput.value.toUpperCase();
 
-    let matchCompatible = document.getElementById('onlyMatchSpecificVersion');
-    let onlyMatchSpecificVersion = matchCompatible.checked;
-
     let container = document.getElementById('metadataList');
     let cards = container.getElementsByClassName('plugin-metadata-card');
 
@@ -28,7 +25,7 @@
       let version = card.getAttribute('data-version');
 
       let searchMatches = name.indexOf(searchFilter) >= 0;
-      let versionMatches = targetVersion == '' || (onlyMatchSpecificVersion ?  version == targetVersion : isCompatible(version, targetVersion) );
+      let versionMatches = targetVersion == '' || isCompatible(version, targetVersion);
 
       card.style.display = searchMatches && versionMatches ? '' : 'none';
     }

--- a/_layouts/plugins.html
+++ b/_layouts/plugins.html
@@ -43,9 +43,8 @@ layout: default
   </div>
 
   <div id="metadataList">
-    {% assign plugins = plugins | sort: "SupportedDriverVersion" | reverse | group_by: "Name" | sort: 'name' %}
-    {%- for plugin in plugins -%}
-      {% assign metadata = plugin.items | first %}
+    {% assign plugins = plugins | sort: "Name" %}
+    {%- for metadata in plugins -%}
       {% assign maxDriverVersionSplit = metadata.SupportedDriverVersion | split: '.' %}
       {%- capture maxDriverVersion -%}
         {% if maxDriverVersionSplit[0] == "0" %}

--- a/_layouts/plugins.html
+++ b/_layouts/plugins.html
@@ -40,12 +40,6 @@ layout: default
         <label style="color: rgba(0,0,0,0.5)" class="form-label" for="pluginVersionSelector">Driver Version</label>
       </div>
     </div>
-    <div class="d-inline-flex p-2">
-        <input type="checkbox" class="btn-check" id="onlyMatchSpecificVersion" autocomplete="off"
-                                                                          onchange="filterInput()">
-        <label class="btn btn-outline-primary" title="When disabled, show all plugins compatible with the selected driver version"
-                                               for="onlyMatchSpecificVersion">Force Version</label>
-    </div>
   </div>
 
   <div id="metadataList">

--- a/_layouts/plugins.html
+++ b/_layouts/plugins.html
@@ -46,6 +46,16 @@ layout: default
     {% assign plugins = plugins | sort: "SupportedDriverVersion" | reverse | group_by: "Name" | sort: 'name' %}
     {%- for plugin in plugins -%}
       {% assign metadata = plugin.items | first %}
+      {% assign maxDriverVersionSplit = metadata.SupportedDriverVersion | split: '.' %}
+      {%- capture maxDriverVersion -%}
+        {% if maxDriverVersionSplit[0] == "0" %}
+          {% assign nextMinor = maxDriverVersionSplit[1] | plus: 1 %}
+          0.{{ nextMinor }}.0.0
+        {% else %}
+          {% assign nextMajor = maxDriverVersionSplit[0] | plus: 1 %}
+          {{ nextMajor }}.0.0.0
+        {% endif %}
+      {%- endcapture -%}
       <div class="card mb-2 plugin-metadata-card"
           data-name="{{ metadata.Name }}" data-version="{{ metadata.SupportedDriverVersion }}">
         <div class="card-body d-flex flex-sm-row flex-column">
@@ -56,7 +66,10 @@ layout: default
               {{ metadata.Description }}
             </div>
           </div>
-          <div class="mt-auto text-center">
+          <div class="mt-auto text-end">
+            <div class="flex-sm-fill mb-2">
+              <span class="text-muted">Driver Compatibility: <span>&gt;= {{ metadata.SupportedDriverVersion }}</span>, <span>&lt; {{ maxDriverVersion }}</span></span>
+            </div>
             {%- if metadata.DownloadUrl != "" -%}
             <a role="button" class="btn btn-primary me-1 w-10" href="{{ metadata.DownloadUrl }}">
               Download

--- a/_layouts/plugins.html
+++ b/_layouts/plugins.html
@@ -26,15 +26,25 @@ layout: default
             {%- endfor -%}
           {%- endfor -%}
 
-          {% assign otdversions = otdversions | sort | uniq %}
+          {% assign otdversions = otdversions | sort | uniq | reverse %}
 
           <option value="">All Versions</option>
+          {% assign elementAttributes = " selected" %}
           {%- for version in otdversions -%}
-            <option value="{{version}}">{{version}}</option>
+            <option value="{{version}}" {{elementAttributes}}>{{version}}</option>
+            {% if elementAttributes %}
+              {% assign elementAttributes = nil %}
+            {% endif %}
           {%- endfor -%}
         </select>
         <label style="color: rgba(0,0,0,0.5)" class="form-label" for="pluginVersionSelector">Driver Version</label>
       </div>
+    </div>
+    <div class="d-inline-flex p-2">
+        <input type="checkbox" class="btn-check" id="onlyMatchSpecificVersion" autocomplete="off"
+                                                                          onchange="filterInput()">
+        <label class="btn btn-outline-primary" title="When disabled, show all plugins compatible with the selected driver version"
+                                               for="onlyMatchSpecificVersion">Force Version</label>
     </div>
   </div>
 

--- a/_layouts/plugins.html
+++ b/_layouts/plugins.html
@@ -52,7 +52,7 @@ layout: default
           <div class="flex-sm-fill p-2">
             <span class="h4">{{ metadata.Name }}</span>
             <span class="text-sm text-muted"> - {{ metadata.Owner }} - {{ metadata.PluginVersion }}</span><br/>
-            <div class="mt-2 ms-2">
+            <div class="mt-2">
               {{ metadata.Description }}
             </div>
           </div>


### PR DESCRIPTION
This is more intuitive for the user - selecting a driver version will now show all compatible plugins by default.

New default look:
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/421345/c46462bf-3026-4d65-aeb2-c78bdb4fc329)

Previously, it would show every single plugin in the database, and only filter plugins exactly matching the driver version.

Also fixes #14