### PR TITLE
 Consistent Formatting in README Markdown File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# opentabletdriver.github.io
-The next version of OpenTabletDriver.Web
+# [opentabletdriver.github.io](https://opentabletdriver.github.io)
+*The next version of OpenTabletDriver.Web*
 
-# Local Development
+---
 
-## Requirements
+## Local Development
+
+### Requirements
 
 - `rubygems`
+
+---
 
 ## Steps
 
@@ -17,50 +21,54 @@ $ git submodule update
 $ bundle install
 $ bundle exec jekyll serve --livereload
 ```
+---
 
 # FAQ
 
-## How do I add an wiki entry?
+### **How do I add a wiki entry?**
 
-Add or edit the appropriate markdown file in the appropriate `_wiki/` folder.
+To add or edit a wiki entry, modify the appropriate markdown file in the `_wiki/` folder.
 
-## I can't find the "index" page for a page! (e.g. site/Wiki)
+### **I can't find the "index" page for a page! (e.g., site/Wiki)**
 
-Single-path URL's are permalinked to files in `_sections`
+For pages with single-path URLs (e.g., site/Wiki), they are permalinked to files in the `_sections` folder.
 
-## How do I update the rouge highlighter style?
+### **How do I update the Rouge highlighter style?**
 
-`bundle exec rougify style > assets/rougehl.css`
+To update the Rouge highlighter style, use the following command:
 
-## How can I check if I have internal links that don't use the `{% link %}` paradigm?
+```bash
+bundle exec rougify style > assets/rougehl.css
+```
+
+### **How can I check if I have internal links that don't use the `{% link %}` paradigm?**
+
+You can check for internal links without the `{% link %}` paradigm using the following command:
 
 ```bash
 cd <website root>
-grep -R --exclude-dir vendor --include="*.md" '](' | grep -v '](#' | grep -v ']({%' | grep -v '](http' | grep -v '](//'`
+grep -R --exclude-dir vendor --include="*.md" '](' | grep -v '](#' | grep -v ']({%' | grep -v '](http' | grep -v '](//'
 ```
+---
 
-## How are the Wiki ToC's generated?
+# Contributors to Old OpenTabletDriver.Web
 
-With [allejo/jekyll-toc](https://github.com/allejo/jekyll-toc). We are using 1.2.0.
+[View Contributors](https://github.com/OpenTabletDriver/OpenTabletDriver.Web/graphs/contributors)
 
-# Contributors to old OpenTabletDriver.Web
+This site has been ported directly from the old repository to Jekyll and may contain code, assets, information, or other contributions by the following individuals:
 
-[Link](https://github.com/OpenTabletDriver/OpenTabletDriver.Web/graphs/contributors)
+- [@InfinityGhost](https://github.com/InfinityGhost)
+- [@jamesbt365](https://github.com/jamesbt365)
+- [@gonX](https://github.com/gonX)
+- [@vedxyz](https://github.com/vedxyz)
+- [@Hypfer](https://github.com/Hypfer)
+- [@TakanashiDavi](https://github.com/TakanashiDavi)
+- [@Sublimelime](https://github.com/Sublimelime)
+- [@nerd](https://github.com/nerd)
+- [@FlafyDev](https://github.com/FlafyDev)
+- [@DanisDGK](https://github.com/DanisDGK)
+- [@Zyfarok](https://github.com/Zyfarok)
+- [@X9VoiD](https://github.com/X9VoiD)
+- [@MicrochipQ](https://github.com/MicrochipQ)
+- [@vgf89](https://github.com/vgf89)
 
-As this site is ported directly from the old repository to Jekyll, the site may contain
-code, assets, information or other contributions by:
-
-[@InfinityGhost](https://github.com/InfinityGhost)\\
-[@jamesbt365](https://github.com/jamesbt365)\\
-[@gonX](https://github.com/gonX)\\
-[@vedxyz](https://github.com/vedxyz)\\
-[@Hypfer](https://github.com/Hypfer)\\
-[@TakanashiDavi](https://github.com/TakanashiDavi)\\
-[@Sublimelime](https://github.com/Sublimelime)\\
-[@nerd](https://github.com/nerd)\\
-[@FlafyDev](https://github.com/FlafyDev)\\
-[@DanisDGK](https://github.com/DanisDGK)\\
-[@Zyfarok](https://github.com/Zyfarok)\\
-[@X9VoiD](https://github.com/X9VoiD)\\
-[@MicrochipQ](https://github.com/MicrochipQ)\\
-[@vgf89](https://github.com/vgf89)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 - `rubygems`
 
----
-
 ## Steps
 
 ```bash


### PR DESCRIPTION
### Issue Description
Correctly formatted README.md file with consistent formatting and linting. Also, included `<hr/>` prior to H3. 

Solved Issue #11 

### Screenshots

![readme](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/108212023/1394fb67-7039-4ef3-a1e1-908f57fa062a)
_Screenshot 1_