### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-opentabletdriver.net

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: OpenTabletDriver
 description: >- # this means to ignore newlines until "baseurl:"
   OpenTabletdriver is an open source, cross-platform, low latency, user-mode tablet driver.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: https://opentabletdriver.net # the base hostname & protocol for your site, e.g. http://example.com
+url: https://opentabletdriver.github.io # the base hostname & protocol for your site, e.g. http://example.com
 
 # Site variables
 latest_otd_version: v0.6.3.0


### PR DESCRIPTION
We can use the old links for support for now

When the site changes DNS over it should redirect to the correct links anyway

This commit can be reverted once DNS is ready to move