### PR TITLE
Make whitespace more consistent around card button

### DIFF
--- a/_layouts/plugins.html
+++ b/_layouts/plugins.html
@@ -65,25 +65,27 @@ layout: default
               {{ metadata.Description }}
             </div>
           </div>
-          <div class="mt-auto text-end">
-            <div class="flex-sm-fill mb-2">
-              <span class="text-muted">Driver Compatibility: <span>&gt;= {{ metadata.SupportedDriverVersion }}</span>, <span>&lt; {{ maxDriverVersion }}</span></span>
+          <div class="d-flex flex-column p-2 text-end">
+            <div class="mb-1">
+              <span class="text-muted">Driver Compatibility: &gt;= {{ metadata.SupportedDriverVersion }}, &lt; {{ maxDriverVersion }}</span>
             </div>
-            {%- if metadata.DownloadUrl != "" -%}
-            <a role="button" class="btn btn-primary me-1 w-10" href="{{ metadata.DownloadUrl }}">
-              Download
-            </a>
-            {%- endif -%}
-            {%- if metadata.WikiUrl != "" -%}
-            <a role="button" class="btn btn-info me-1" href="{{ metadata.WikiUrl }}">
-              Wiki
-            </a>
-            {%- endif -%}
-            {%- if metadata.RepositoryUrl != "" -%}
-            <a role="button" class="btn btn-info" href="{{ metadata.RepositoryUrl }}">
-              Source
-            </a>
-            {%- endif -%}
+            <div class="mt-auto">
+              {%- if metadata.DownloadUrl != "" -%}
+              <a role="button" class="btn btn-primary me-1 w-10" href="{{ metadata.DownloadUrl }}">
+                Download
+              </a>
+              {%- endif -%}
+              {%- if metadata.WikiUrl != "" -%}
+              <a role="button" class="btn btn-info me-1" href="{{ metadata.WikiUrl }}">
+                Wiki
+              </a>
+              {%- endif -%}
+              {%- if metadata.RepositoryUrl != "" -%}
+              <a role="button" class="btn btn-info" href="{{ metadata.RepositoryUrl }}">
+                Source
+              </a>
+              {%- endif -%}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Wide View

Before:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/a1bb5422-bb6b-44ba-be38-ad58496e1315)

After:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/8db6cc72-3db9-424b-870e-d741cd7c79c2)

### Narrow View

Before:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/93a5ecc9-9b4b-4dfe-aad0-7598a1a5da75)

After:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/b4651cc7-d492-45c0-8279-f1356d3e2db8)

---

Also removed the extra spans, I'm not sure what it's for but it doesn't affect layout in any way afaict.