### PR TITLE
config: Fix typo in site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@
 
 title: OpenTabletDriver
 description: >- # this means to ignore newlines until "baseurl:"
-  OpenTabletdriver is an open source, cross-platform, low latency, user-mode tablet driver.
+  OpenTabletDriver is an open source, cross-platform, low latency, user-mode tablet driver.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: https://opentabletdriver.net # the base hostname & protocol for your site, e.g. http://example.com
 


### PR DESCRIPTION
Mostly a parity fix, fast-tracking this change.