### PR TITLE
Fix .NET runtime links

### DIFF
--- a/_sections/Framework.md
+++ b/_sections/Framework.md
@@ -4,7 +4,7 @@ title: Frameworks
 
 ### Windows
 
-[x64](https://aka.ms/dotnet/current/windowsdesktop-runtime-win-x64.pkg)
+[x64](https://aka.ms/dotnet/current/windowsdesktop-runtime-win-x64.exe)
 
 ---
 
@@ -24,8 +24,4 @@ See the [official Linux installation documentation](https://docs.microsoft.com/e
 
 ### Uncommon builds
 
-[MacOS x86](https://aka.ms/dotnet/current/dotnet-runtime-osx-x86.pkg)
-
-[Windows x86](https://aka.ms/dotnet/current/windowsdesktop-runtime-win-x86.pkg)
-
-[Windows arm64](https://aka.ms/dotnet/current/windowsdesktop-runtime-win-arm64.pkg)
+[Windows arm64](https://aka.ms/dotnet/current/windowsdesktop-runtime-win-arm64.exe)

--- a/_sections/Framework.md
+++ b/_sections/Framework.md
@@ -4,15 +4,15 @@ title: Frameworks
 
 ### Windows
 
-[x64](https://aka.ms/dotnet/current/windowsdesktop-runtime-win-x64.exe)
+[x64](https://aka.ms/dotnet/6.0/windowsdesktop-runtime-win-x64.exe)
 
 ---
 
 ### MacOS
 
-[arm64](https://aka.ms/dotnet/current/dotnet-runtime-osx-arm64.pkg)
+[arm64](https://aka.ms/dotnet/6.0/dotnet-runtime-osx-arm64.pkg)
 
-[x86-64/x64 (Intel based)](https://aka.ms/dotnet/current/dotnet-runtime-osx-x64.pkg)
+[x86-64/x64 (Intel based)](https://aka.ms/dotnet/6.0/dotnet-runtime-osx-x64.pkg)
 
 ---
 
@@ -24,4 +24,4 @@ See the [official Linux installation documentation](https://docs.microsoft.com/e
 
 ### Uncommon builds
 
-[Windows arm64](https://aka.ms/dotnet/current/windowsdesktop-runtime-win-arm64.exe)
+[Windows arm64](https://aka.ms/dotnet/6.0/windowsdesktop-runtime-win-arm64.exe)


### PR DESCRIPTION
Draft for multiple reasons:
- DDL links exist, i just don't know if they will break so I haven't included them
- can't find a link for dotnet for osx x86? (did this even exist)?? so i haven't updated it.
- Not sure why we even include "uncommon builds" because we don't even have OTD binaries for these? Users have to compile them for themselves which you haven't included the SDKs or instructions for.
- MacOS builds are self contained, we have no reason to include the dotnet package link here. (we don't link it on the installation guide though).