### PR TITLE
Improve Linux install instructions

### DIFF
--- a/_wiki/Documentation/UdevRules.md
+++ b/_wiki/Documentation/UdevRules.md
@@ -46,6 +46,22 @@ For other distros, refer to your distro's documentation on how to update the ini
 
 Refer to your distro's documentation on how to remove udev rules of the name `90-opentabletdriver.rules` or `99-opentabletdriver.rules`.
 
+#### Legacy package
+
+If you're using a version of OpenTabletDriver below 0.6.3.0, run the script in the [Standard FHS distro](#standard-fhs-distro) section and then run the following script:
+
+```bash
+git clone https://github.com/OpenTabletDriver/OpenTabletDriver.git
+cd OpenTabletDriver
+
+./generate-udev-rules.sh | sudo tee /etc/udev/rules.d/70-opentabletdriver.rules
+sudo cp ./eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf /etc/modprobe.d/99-opentabletdriver.conf
+sudo cp ./eng/linux/Generic/usr/lib/modules-load.d/opentabletdriver.conf /etc/modules-load.d/opentabletdriver.conf
+
+cd ..
+rm -rf OpenTabletDriver
+```
+
 ### Built from source
 
 Make sure you built OpenTabletDriver via [these instructions](https://github.com/OpenTabletDriver/OpenTabletDriver#linux) and extracted the generic binary tarball correctly.

--- a/_wiki/Documentation/UdevRules.md
+++ b/_wiki/Documentation/UdevRules.md
@@ -60,6 +60,10 @@ sudo cp ./eng/linux/Generic/usr/lib/modules-load.d/opentabletdriver.conf /etc/mo
 
 cd ..
 rm -rf OpenTabletDriver
+
+sudo modprobe uinput
+sudo modprobe -r wacom
+sudo modprobe -r hid_uclogic
 ```
 
 ### Built from source

--- a/_wiki/Documentation/UdevRules.md
+++ b/_wiki/Documentation/UdevRules.md
@@ -54,7 +54,7 @@ If you're using a version of OpenTabletDriver below 0.6.3.0, run the script in t
 git clone https://github.com/OpenTabletDriver/OpenTabletDriver.git
 cd OpenTabletDriver
 
-./generate-udev-rules.sh | sudo tee /etc/udev/rules.d/70-opentabletdriver.rules
+./generate-rules.sh | sudo tee /etc/udev/rules.d/70-opentabletdriver.rules
 sudo cp ./eng/linux/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf /etc/modprobe.d/99-opentabletdriver.conf
 sudo cp ./eng/linux/Generic/usr/lib/modules-load.d/opentabletdriver.conf /etc/modules-load.d/opentabletdriver.conf
 

--- a/_wiki/Documentation/UdevRules.md
+++ b/_wiki/Documentation/UdevRules.md
@@ -46,7 +46,7 @@ For other distros, refer to your distro's documentation on how to update the ini
 
 Refer to your distro's documentation on how to remove udev rules of the name `90-opentabletdriver.rules` or `99-opentabletdriver.rules`.
 
-#### Legacy package
+#### Legacy package {#legacy-package}
 
 If you're using a version of OpenTabletDriver below 0.6.3.0, run the script in the [Standard FHS distro](#standard-fhs-distro) section and then run the following script:
 

--- a/_wiki/Documentation/UdevRules.md
+++ b/_wiki/Documentation/UdevRules.md
@@ -62,8 +62,8 @@ cd ..
 rm -rf OpenTabletDriver
 
 sudo modprobe uinput
-sudo modprobe -r wacom
-sudo modprobe -r hid_uclogic
+sudo rmmod wacom
+sudo rmmod hid_uclogic
 ```
 
 ### Built from source

--- a/_wiki/FAQ/Linux.md
+++ b/_wiki/FAQ/Linux.md
@@ -110,7 +110,7 @@ Artist mode does not support regular mouse buttons. You will need to use artist 
 
 ---
 
-### The daemon does not start on boot
+### How to autostart daemon on boot? {#autostart}
 
 #### systemd {#systemd-autostart}
 

--- a/_wiki/FAQ/Linux.md
+++ b/_wiki/FAQ/Linux.md
@@ -120,7 +120,7 @@ Make sure that you have enabled the systemd service:
 systemctl user enable opentabletdriver.service --now
 ```
 
-If this does not work, this means that the desktop environment is not configured correctly to integrate with systemd. In such case, refer to your desktop environment's documentation on how to autostart processes on login. The command to execute on login is:
+If daemon doesn't start on boot, this means that the desktop environment is not configured correctly to integrate with systemd. In such case, refer to your desktop environment's documentation on how to autostart processes on login. The command to execute on login is:
 
 ```bash
 otd-daemon

--- a/_wiki/Install/Linux.md
+++ b/_wiki/Install/Linux.md
@@ -29,6 +29,7 @@ See solutions from Microsoft [here](https://learn.microsoft.com/en-us/dotnet/cor
     # This will install the package
     sudo dnf install ./OpenTabletDriver.rpm
     ```
+    > This assumes that you are in the directory in which you downloaded OpenTabletDriver to.
  3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 ---

--- a/_wiki/Install/Linux.md
+++ b/_wiki/Install/Linux.md
@@ -13,7 +13,7 @@ title: Linux Installation Guide
     sudo apt install ./OpenTabletDriver.deb
     ```
     > This assumes that you are in the directory in which you downloaded OpenTabletDriver to.
- 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
+ 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 If you have the Microsoft dotnet repository installed you will have to either make sure you are not using any packages from that repository or use everything dotnet based off that. Mixing packages from different repositories will cause `libhostfxr` issues.
 
@@ -30,7 +30,7 @@ See solutions from Microsoft [here](https://learn.microsoft.com/en-us/dotnet/cor
     sudo dnf install ./OpenTabletDriver.rpm
     ```
     > This assumes that you are in the directory in which you downloaded OpenTabletDriver to.
- 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
+ 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 ---
 
@@ -41,7 +41,7 @@ You can install OpenTabletDriver from the AUR. There are two ways to do this.
 - via [AUR helper](#aur-helper-method)
 - manually via [makepkg](#manual-makepkg-method)
 
-Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
+Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 #### AUR helper method {#aur-helper-method}
 
@@ -89,7 +89,7 @@ x11-drivers/OpenTabletDriver-bin ~amd64
 sudo emerge OpenTabletDriver-bin
 ```
 
-4. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
+4. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 ---
 

--- a/_wiki/Install/Linux.md
+++ b/_wiki/Install/Linux.md
@@ -46,10 +46,13 @@ Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instru
 #### AUR helper method {#aur-helper-method}
 
  1. Use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install the `opentabletdriver` AUR package.
- 2. Run the following command in a terminal
+ 2. Run the following commands in a terminal
 ```sh
 # Regenerate initramfs
 sudo mkinitcpio -P
+# Unload kernel modules
+sudo rmmod wacom
+sudo rmmod hid_uclogic
 ```
 
 #### `makepkg` method {#manual-makepkg-method}
@@ -65,6 +68,9 @@ cd ..
 rm -rf opentabletdriver
 # Regenerate initramfs
 sudo mkinitcpio -P
+# Unload kernel modules
+sudo rmmod wacom
+sudo rmmod hid_uclogic
 ```
 
 ---

--- a/_wiki/Install/Linux.md
+++ b/_wiki/Install/Linux.md
@@ -5,44 +5,55 @@ title: Linux Installation Guide
 ### Ubuntu / Debian {#debian}
  1. Download the [latest release]({{ site.otd_release_url }}/OpenTabletDriver.deb) <small class="text-muted">(OpenTabletDriver.deb)</small>
  2. Run the following commands in a terminal
+    ```bash
+    # Update the package list
+    sudo apt update
 
-> This assumes that you are in the directory in which you downloaded OpenTabletDriver to.
+    # This will install the package
+    sudo apt install ./OpenTabletDriver.deb
+    ```
+    > This assumes that you are in the directory in which you downloaded OpenTabletDriver to.
+ 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
-```sh
-# Update the package list
-sudo apt update
+If you have the Microsoft dotnet repository installed you will have to either make sure you are not using any packages from that repository or use everything dotnet based off that. Mixing packages from different repositories will cause `libhostfxr` issues.
 
-# This will install the package, assuming you are in the correct directory
-sudo apt install ./OpenTabletDriver.deb
+See solutions from Microsoft [here](https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup#solutions) and remove the Microsoft repositories and packages if you're experiencing `libhostfxr` issues.
 
-# Reload the systemd user unit daemon
-systemctl --user daemon-reload
+---
 
-# Enable and start the user service
-systemctl --user enable opentabletdriver --now
-```
+### Fedora {#rpm}
 
-If you have the Microsoft dotnet repository installed you will have to either make sure you are not using any packages from that repository or use everything dotnet based off that. Mixing packages from different repositories will cause libhostfxr issues. If you are experiencing these see these solutions from Microsoft [here](https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup#solutions) and remove the Microsoft repositories and packages.
+ 1. Download the [latest release]({{ site.otd_release_url }}/OpenTabletDriver.rpm) <small class="text-muted">(OpenTabletDriver.rpm)</small>
+ 2. Run the following commands in a terminal
+    ```bash
+    # This will install the package
+    sudo dnf install ./OpenTabletDriver.rpm
+    ```
+ 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 ---
 
 ### Arch Linux {#arch}
- 1. Use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install the `opentabletdriver` AUR package.
- 2. Run the following commands in a terminal
 
+You can install OpenTabletDriver from the AUR. There are two ways to do this.
+
+- via [AUR helper](#aur-helper-method)
+- manually via [makepkg](#manual-makepkg-method)
+
+Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
+
+#### AUR helper method {#aur-helper-method}
+
+ 1. Use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install the `opentabletdriver` AUR package.
+ 2. Run the following command in a terminal
 ```sh
-# Reload the systemd user unit daemon
-systemctl --user daemon-reload
-# Enable and start the user service
-systemctl --user enable opentabletdriver --now
+# Regenerate initramfs
+sudo mkinitcpio -P
 ```
 
-Alternatively, you can install `opentabletdriver` without an AUR helper.
+#### `makepkg` method {#manual-makepkg-method}
 
-#### Enabling the OpenTabletDriver service
-
-- Run the following commands in a terminal to install and enable the OpenTabletDriver service.
-
+ 1. Run the following commands
 ```sh
 # Downloads the pkgbuild from the AUR.
 git clone https://aur.archlinux.org/opentabletdriver.git
@@ -51,10 +62,8 @@ cd opentabletdriver && makepkg -si
 # Clean up leftovers
 cd ..
 rm -rf opentabletdriver
-# Reload the systemd user unit daemon
-systemctl --user daemon-reload
-# Enable and start the user service
-systemctl --user enable opentabletdriver --now
+# Regenerate initramfs
+sudo mkinitcpio -P
 ```
 
 ---
@@ -78,6 +87,8 @@ x11-drivers/OpenTabletDriver-bin ~amd64
 # Install the OpenTabletDriver package
 sudo emerge OpenTabletDriver-bin
 ```
+
+4. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#systemd-autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 ---
 


### PR DESCRIPTION
## Changes

- Add instructions for legacy packages.
- Add Fedora instructions.
- Minor tweaks to other install instructions to not rely on systemd service.
- Unload kernel modules on install on Arch Linux.