### PR TITLE
Fix layout issues

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,13 +1,15 @@
 <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark border-bottom border-dark box-shadow mb-3">
-  <div class="container">
-    <img class="pr-3" src="{% link assets/otd.png %}" height="64">
-    <a class="navbar-brand text-white ms-3" href="{% link index.md %}">OpenTabletDriver</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                                                                                                             aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-      <ul class="navbar-nav flex-grow-1">
+  <div class="container d-flex flex-wrap">
+    <div class="d-flex flex-row align-items-center flex-grow-1 flex-sm-grow-0 justify-content-between justify-content-sm-start">
+      <img src="{% link assets/otd.png %}" height="64">
+      <a class="navbar-brand text-white ms-3" href="{% link index.md %}">OpenTabletDriver</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+                                                                                                              aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+    </div>
+    <div class="navbar-collapse collapse">
+      <ul class="navbar-nav">
         <li class="nav-item">
           <a class="nav-link text-light" href="{% link index.md %}">Home</a>
         </li>

--- a/_layouts/wikipage.html
+++ b/_layouts/wikipage.html
@@ -5,11 +5,11 @@ layout: default
 {% include wiki/header.html %}
 
 <div class="row">
-  <div class="col-xs-12 col-sm-4 col-md-3">
+  <div class="col-xs col-sm-4 col-md-3">
     <strong>Contents</strong>
     {% include toc.html html=content id="toc" h_max=3 %}
   </div>
-  <div class="col markdown-content fix-fouc">
+  <div class="col-xs col-sm-8 col-md-9 markdown-content fix-fouc">
     {{ content | inject_anchors }}
   </div>
 </div>


### PR DESCRIPTION
## Changes

### Fix bootstrap grid sizing of wiki page

This issue somehow only manifests on some pages, but this commit fixes it completely.

Before:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/b4bbda20-32a4-4fb4-96e1-d6b22b5d9f66)

After:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/529fc422-3ad0-466b-9de1-6e6a353754ae)

### Fix OpenTabletDriver title layout issue

Before:

`Large (>= 992px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/e615cabe-eb95-41bc-8382-6f54879c8207)

`Medium (>= 768px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/d001415b-5df8-48e2-ac0f-9302096cc7e8)

`Small (>= 576px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/a84811f2-3c7f-44c9-978c-5d1350e4bd8a)

`Extra Small (< 576px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/bf34ba58-f37b-4b7b-b82b-b53a2ee2631d)

After:

`Large (>= 992px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/0c6f3371-6884-476b-b921-7526c681bd12)

`Medium (>= 768px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/9b1d06bb-e594-414c-852f-e01a6dd925eb)

`Small (>= 576px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/9111bfef-bb72-4c7f-a3a9-8ca2c0e8e995)

`Extra Small (< 576px)`
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/5f121c1a-9e35-4e7b-bd0d-1c61927e2e12)
