### PR TITLE
Lint markdown in PRs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 100
 
+# markdown is also linted with markdownlint-cli, see .markdownlint.yaml in project root
 [*.md]
 # not having this results in readability-vs-presentation confusion
 max_line_length = unset

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@ eb1579be0bf7eca895ca2c28d4e2bb6b9ecef24f
 
 # Fix Markdown indentation
 5063653d7158f261136ac931ac019719f590049e
+
+# Apply Markdown linting
+7a6b7f119a40b3521d49c5a353c791051282022b

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,3 +14,18 @@ jobs:
       - name: Linting with editorconfig-checker
         run: |
           docker run --rm --volume=${{ github.workspace }}:/check mstruebing/editorconfig-checker
+
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Linting with markdownlint-cli
+        # uses: nosborn/github-action-markdown-cli@v3.3.0
+        # using our own package until MD051 isn't falsely triggered
+        uses: gonX/github-action-markdown-cli@e088220481709c8ff1fbff0fc21addf027b95dc1
+        with:
+          files: .
+          dot: true
+          ignore_files: site/_includes/tablets.md # upstream file

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,163 @@
+# Configuration for markdownlint-cli (mdl-cli)
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md for rules
+# Template: https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/.markdownlint.yaml
+# Unspecified rules are enabled by default, but they are commented for clarity
+
+default: true
+
+# MD001: Ensure incremental headings, e.g. always h3 -> h4 -> h5, never h3 -> h5
+
+# MD003: Heading style, atx is '# H1 Title', '### H3 Title', etc.
+MD003:
+  style: "atx"
+
+# MD004: <ul> style
+MD004:
+  style: "dash" # e.g. '- This is text inside of a <li> inside of an <ul>'
+
+# MD005: general list indentation consistency
+
+# MD007: <ul> indentation
+MD007:
+  indent: 4
+
+# MD009: trailing spaces
+MD009:
+  br_spaces: 0 # use a backslash to break your line instead
+  strict: true
+
+# MD010: hard tabs (whitespace)
+MD010:
+  spaces_per_tab: 2
+
+# MD011: Reversed link syntax
+
+# MD012: Multiple consecutive blank lines
+
+# MD013: Max line length
+#        Disable for now, this needs consideration before enabling
+MD013: false
+
+# MD014: No Dollar signs in shell code unless output is included
+
+# MD018: No space after hash on atx style heading, avoids '#Heading'
+
+# MD019: Multiple spaces after hash, counterpart to MD018
+
+# MD020: Closed atx equivalent of MD018
+
+# MD021: Closed atx equivalent of MD019
+
+# MD022: Headings should be surround by blank lines
+
+# MD023: Headings must start at the beginning of the line
+
+# MD024: Headings with the same content
+#     Can be disabled when we can handle multiple headings with same name
+
+# MD025: Multiple top-level headings in same document (H1's)
+
+# MD026: Trailing punctuation in heading
+
+# MD027: Multiple spaces after blockquote
+
+# MD028: Blank line inside blockquote
+
+# MD029: Ordered list item prefix
+MD029:
+  style: "ordered" # can be changed eventually
+
+# MD030: Spaces after list markers
+
+# MD031: Fenced code blocks (```) should be surrounded by blank lines
+
+# MD032: Lists should be surrounded by blank lines
+
+# MD033: Inline HTML
+MD033:
+  allowed_elements:
+    - "small" # no good alternative in markdown
+    - "u" # no good alternative in markdown
+    - "kbd" # keyboard icons
+
+# MD034: Disallow Bare URLs
+
+# MD035: Horizontal rule style
+MD035:
+  string: "---"
+
+# MD036: Emphasis used instead of a heading
+
+# MD037: Spaces inside emphasis markers
+#        TODO: disabled because liquid tags causes false positives with this
+MD037: false
+
+# MD038: Spaces inside code span elements
+
+# MD039: Spaces inside link text
+
+# MD040: Fenced code blocks (```) should have a language specified
+
+# MD041: First line should be a top heading, posts excluded
+MD041:
+  front_matter_title: "^\\s*(title|no_MD041)\\s*[:=]" # Allow front matter to opt out with no_MD041
+
+# MD042: No empty links
+
+# MD043: Required heading structure
+#        Not used if not defined, and it's too specific for us to use
+
+# MD044: Names should have the correct capitalization
+#        Disabled for now because liquid tags confuses linting
+MD044: false
+#  # we have some instances of lowercase being relevant
+#  code_blocks: false
+#  html_elements: false
+#  # any sort of capitalization sometimes qualifies it to also have a space at end
+#  names:
+#    - "OpenTabletDriver "
+#    - "opentabletdriver.github.io"
+#    - "OpenTabletDriver.Web"
+#    - "Plugin-Repository"
+#    - "Linux"
+#    - "udev"
+#    - "AUR"
+#    - "makepkg"
+#    - "Eto"
+#    - "Avalonia"
+#    - "Krita"
+#    - "GIMP"
+#    - "Windows"
+#    - "Discord"
+#    - "GitHub"
+
+# MD045: Images should have alt text
+
+# MD046: Code block style (fenced or indented)
+MD046:
+  style: "fenced"
+
+# MD047: Files should end with a single newline character
+
+# MD048: Code fence style (``` or ~~~)
+MD048:
+  style: "backtick"
+
+# MD049: Emphasis style (*Italics* or _Italics_)
+MD049:
+  style: "asterisk"
+
+# MD050: Strong style (**Bold** or __Bold__)
+MD050:
+  style: "asterisk"
+
+# MD051: Link fragments should be valid
+
+# MD052: Reference links and images should use a label that is defined
+
+# MD053: Link and image reference definitions should be needed
+
+# MD054: Link and image style
+MD054:
+  autolinks: false # no raw URLs
+  url_inline: false # no URLs with same title as URL, instead remove http(s) from your title

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ To update the Rouge highlighter style, use the following command:
 bundle exec rougify style > site/assets/css/rougehl.css
 ```
 
+### **How do I lint the project?**
+
+Any [EditorConfig](https://editorconfig.org/) compliant linter like [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)
+
+For Markdown specifically we use `markdownlint-cli`. Example command:
+
+```bash
+cd <website root>
+markdownlint --ignore site/vendor/ --ignore site/_data/plugin-repository/ --ignore site/_includes/tablets.md . 2>&1 | less
+```
+
 # Contributors to Old OpenTabletDriver.Web
 
 [View Contributors](https://github.com/OpenTabletDriver/OpenTabletDriver.Web/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # [opentabletdriver.github.io](https://opentabletdriver.github.io)
-*The next version of OpenTabletDriver.Web*
+
+The next version of OpenTabletDriver.Web
 
 ## Local Development
 
@@ -10,13 +11,13 @@
 ## Steps
 
 ```bash
-$ git submodule update --init # submodules contain plugin metadata
-$ cd site/
-$ bundle install
-$ bundle exec jekyll serve --livereload
+git submodule update --init # submodules contain plugin metadata
+cd site/
+bundle install
+bundle exec jekyll serve --livereload
 ```
 
-# FAQ
+## FAQ
 
 ### **How do I add a wiki entry?**
 
@@ -45,7 +46,7 @@ cd <website root>
 markdownlint --ignore site/vendor/ --ignore site/_data/plugin-repository/ --ignore site/_includes/tablets.md . 2>&1 | less
 ```
 
-# Contributors to Old OpenTabletDriver.Web
+## Contributors to Old OpenTabletDriver.Web
 
 [View Contributors](https://github.com/OpenTabletDriver/OpenTabletDriver.Web/graphs/contributors)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,6 @@
-# Roadmap (rough order)
+# TODO
+
+## Roadmap (rough order)
 
 - [x] Tablets
 - [x] GitHub link
@@ -18,7 +20,6 @@
 - [ ] Move DNS
 - [ ] Close OpenTabletDriver.Web
 
-# Other stuff:
+## Other stuff
 
 - [ ] Bus factor
-

--- a/site/_plugins/rouge-logoutput-lexer.rb
+++ b/site/_plugins/rouge-logoutput-lexer.rb
@@ -1,0 +1,14 @@
+Jekyll::Hooks.register :site, :pre_render do |site|
+  require "rouge"
+
+  class MoreJSLexer < Rouge::RegexLexer
+    title "OTD Output"
+    desc "Used for wrapping OpenTabletDriver log output"
+    tag 'otdlog'
+
+    state :root do
+      rule %r/#.*$/, Comment
+      rule %r/.+/, Text
+    end
+  end
+end

--- a/site/_wiki/Documentation/RequiredPermissions.md
+++ b/site/_wiki/Documentation/RequiredPermissions.md
@@ -37,7 +37,7 @@ latest version, refer to the instructions below depending on if you installed Op
 - [Package manager](#package-manager), or
 - [Built from source](#built-from-source)
 
-However if you're using a version of OpenTabletDriver _below_ **0.6.3.0** and somehow cannot update
+However if you're using a version of OpenTabletDriver *below* **0.6.3.0** and somehow cannot update
 to the latest version, refer to the [Legacy package](#legacy-package) section.
 
 ### Package manager
@@ -134,7 +134,7 @@ Refer to your distro's documentation on how to remove udev rules of the name
 `90-opentabletdriver.rules` or `99-opentabletdriver.rules` and a kernel module blacklist named
 `blacklist.conf` containing:
 
-```
+```conf
 blacklist wacom
 blacklist hid_uclogic
 ```

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -12,7 +12,7 @@ Verify if your tablet is in the list of supported tablets [here]({% link _sectio
 
 ### My tablet is supported but not detected? {#tablet-not-detected}
 
-OpenTabletDriver currently has _no support_ for tablets connected via Bluetooth. Make sure that your tablet is connected via USB. There is partial support for tablets connected via wireless dongle.
+OpenTabletDriver currently has *no support* for tablets connected via Bluetooth. Make sure that your tablet is connected via USB. There is partial support for tablets connected via wireless dongle.
 
 Once plugged in, determine if your tablet has good connection to the computer:
 
@@ -102,7 +102,7 @@ Uninstall any other tablet drivers you have installed.
 
 Use the following formulas to get values for the area editor's `Width`, `Height`, `XOffset`, and `YOffset` fields.
 
-**Wacom and Veikk**
+##### Wacom and Veikk
 
 | Term | Definition |
 | --- | --- |
@@ -113,14 +113,14 @@ Use the following formulas to get values for the area editor's `Width`, `Height`
 
 Formula:
 
-```
+```py
 Width = (Right - Left) / LPI * 25.4
 Height = (Bottom - Top) / LPI * 25.4
 XOffset = (Left / LPI * 25.4) + (Width / 2)
 YOffset = (Top / LPI * 25.4) + (Height / 2)
 ```
 
-**XP-Pen**
+##### XP-Pen
 
 | Term | Definition |
 | --- | --- |
@@ -131,14 +131,14 @@ YOffset = (Top / LPI * 25.4) + (Height / 2)
 
 Formula:
 
-```
+```py
 Width = XPW / 3.937
 Height = XPH / 3.937
 XOffset = (Width / 2) + (XPX / 3.937)
 YOffset = (Height / 2) + (XPY / 3.937)
 ```
 
-**Huion and Gaomon**
+##### Huion and Gaomon
 
 | Term | Definition |
 | --- | --- |
@@ -149,7 +149,7 @@ YOffset = (Height / 2) + (XPY / 3.937)
 
 Formula:
 
-```
+```py
 Width = (Right - Left) * TWidth
 Height = (Bottom - Top) * THeight
 XOffset = (Width / 2) + (Left * TWidth)

--- a/site/_wiki/FAQ/Linux.md
+++ b/site/_wiki/FAQ/Linux.md
@@ -69,7 +69,7 @@ Make sure that your kernel has uinput support. If you are using a custom kernel 
 
 ##### Missing uinput device permissions
 
-Symptoms:
+*Symptoms*:
 
 ```otdlog
 Failed to initialize virtual tablet. (error code EACCES)

--- a/site/_wiki/FAQ/Linux.md
+++ b/site/_wiki/FAQ/Linux.md
@@ -17,25 +17,25 @@ If your tablet is connected properly and is supported, but is still not detected
 
 ##### Another driver is found {#hid_uclogic}
 
-_Symptoms_
+*Symptoms*:
 
-```
+```log
 Another tablet driver found: <driver>
 ```
 
-_Solution_
+*Solution*:
 
 - [See here]({% link _wiki/Documentation/RequiredPermissions.md %}#setup-linux)
 
 ##### Insufficient permissions {#udev}
 
-_Symptoms_
+*Symptoms*:
 
-```
+```log
 Not permitted to open HID class device at /dev/hidrawX
 ```
 
-_Solution_
+*Solution*:
 
 - [See here]({% link _wiki/Documentation/RequiredPermissions.md %})
 
@@ -47,37 +47,35 @@ If this is a fresh install and you have not configured your tablet yet, [check l
 
 ##### Missing uinput device
 
-_Symptoms_
+*Symptoms*:
 
-```
+```log
 Failed to initialize virtual tablet. (error code ENODEV)
 ```
 
-_Solution_
+*Solution*:
 
 - Reboot your computer.
 
 ##### Missing uinput device support
 
-_Symptoms_
+*Symptoms*:
 
-```
+```log
 Failed to initialize virtual tablet. (error code ENOENT)
 ```
 
-_Solution_
-
-- Make sure that your kernel has uinput support. If you are using a custom kernel or builds kernel from source, make sure that you have enabled `CONFIG_INPUT_UINPUT` in your kernel configuration. Refer to your distro's documentation regarding kernel configuration.
+Make sure that your kernel has uinput support. If you are using a custom kernel or builds kernel from source, make sure that you have enabled `CONFIG_INPUT_UINPUT` in your kernel configuration. Refer to your distro's documentation regarding kernel configuration.
 
 ##### Missing uinput device permissions
 
-_Symptoms_
+Symptoms:
 
-```
+```log
 Failed to initialize virtual tablet. (error code EACCES)
 ```
 
-_Solution_
+###### Solution
 
 - [See here]({% link _wiki/Documentation/RequiredPermissions.md %})
 

--- a/site/_wiki/FAQ/Linux.md
+++ b/site/_wiki/FAQ/Linux.md
@@ -19,7 +19,7 @@ If your tablet is connected properly and is supported, but is still not detected
 
 *Symptoms*:
 
-```log
+```otdlog
 Another tablet driver found: <driver>
 ```
 
@@ -31,7 +31,7 @@ Another tablet driver found: <driver>
 
 *Symptoms*:
 
-```log
+```otdlog
 Not permitted to open HID class device at /dev/hidrawX
 ```
 
@@ -49,7 +49,7 @@ If this is a fresh install and you have not configured your tablet yet, [check l
 
 *Symptoms*:
 
-```log
+```otdlog
 Failed to initialize virtual tablet. (error code ENODEV)
 ```
 
@@ -61,7 +61,7 @@ Failed to initialize virtual tablet. (error code ENODEV)
 
 *Symptoms*:
 
-```log
+```otdlog
 Failed to initialize virtual tablet. (error code ENOENT)
 ```
 
@@ -71,7 +71,7 @@ Make sure that your kernel has uinput support. If you are using a custom kernel 
 
 Symptoms:
 
-```log
+```otdlog
 Failed to initialize virtual tablet. (error code EACCES)
 ```
 

--- a/site/_wiki/FAQ/Linux.md
+++ b/site/_wiki/FAQ/Linux.md
@@ -75,7 +75,7 @@ Symptoms:
 Failed to initialize virtual tablet. (error code EACCES)
 ```
 
-###### Solution
+*Solution*:
 
 - [See here]({% link _wiki/Documentation/RequiredPermissions.md %})
 

--- a/site/_wiki/FAQ/Windows.md
+++ b/site/_wiki/FAQ/Windows.md
@@ -27,7 +27,7 @@ Please check if your tablet requires WinUSB [here]({% link _sections/Tablets.md 
 
 *Symptoms*:
 
-```log
+```otdlog
 Another tablet driver found: <driver>
 ```
 
@@ -40,8 +40,8 @@ Another tablet driver found: <driver>
 
 *Symptoms*:
 
-```log
-Failed to open file handle to WinUSB interface\
+```otdlog
+Failed to open file handle to WinUSB interface
 SafeHandle cannot be null. (Parameter 'pHandle')
 ```
 

--- a/site/_wiki/FAQ/Windows.md
+++ b/site/_wiki/FAQ/Windows.md
@@ -7,7 +7,6 @@ hide_from_auto_list: true
 first before continuing.**
 - Also check out [Windows App Specific FAQ]({% link _wiki/FAQ/WindowsAppSpecific.md %}) for app-specific instructions.
 
-
 ### My tablet is supported but not detected? {#troubleshooting}
 
 Read [General FAQ]({% link _wiki/FAQ/General.md %}#tablet-not-detected) first before continuing below if you haven't already.
@@ -26,27 +25,27 @@ Please check if your tablet requires WinUSB [here]({% link _sections/Tablets.md 
 
 ##### Tablet driver interference
 
-_Symptoms_
+*Symptoms*:
 
-```
+```log
 Another tablet driver found: <driver>
 ```
 
-_Solution_
+*Solution*:
 
-- Follow the instructions in [TabletDriverCleanup](https://github.com/X9VoiD/TabletDriverCleanup/releases/latest), and make sure to type `y` for every driver found by the utility. Then, restart OTD.
+- Follow the instructions in [TabletDriverCleanup](https://github.com/X9VoiD/TabletDriverCleanup/releases/latest), and make sure to type <kbd>Y</kbd> for every driver found by the utility. Then, restart OTD.
 - If the log entry is still present, try joining our support [Discord]({{ site.discord_invite_url }}) and asking for help in one of the #support channels.
 
 ##### Invalid WinUSB driver state
 
-_Symptoms_
+*Symptoms*:
 
-```sh
-Failed to open file handle to WinUSB interface
+```log
+Failed to open file handle to WinUSB interface\
 SafeHandle cannot be null. (Parameter 'pHandle')
 ```
 
-_Solution_
+*Solution*:
 
 - Restart your computer.
 

--- a/site/_wiki/FAQ/WindowsAppSpecific.md
+++ b/site/_wiki/FAQ/WindowsAppSpecific.md
@@ -20,7 +20,7 @@ See [above](#raw-input).
 
 Do not use Windows Ink.
 
-#### My cursor is shaky!
+#### My cursor is shaky
 
 That's perfectly normal unless it's going really crazy and teleports everywhere. In that case, see this section about resolving [EMI issues]({% link _wiki/FAQ/General.md %}#emi-interference).
 

--- a/site/_wiki/Install/Linux.md
+++ b/site/_wiki/Install/Linux.md
@@ -4,8 +4,10 @@ hide_from_auto_list: true
 ---
 
 ### Ubuntu / Debian {#debian}
+
 1. Download the [latest release]({{ site.otd_release_url }}/OpenTabletDriver.deb) <small class="text-muted">(OpenTabletDriver.deb)</small>
 2. Run the following commands in a terminal
+
     ```bash
     # Update the package list
     sudo apt update
@@ -13,6 +15,7 @@ hide_from_auto_list: true
     # This will install the package
     sudo apt install ./OpenTabletDriver.deb
     ```
+
     > This assumes that you are in the directory in which you downloaded OpenTabletDriver to.
 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
@@ -24,10 +27,12 @@ See solutions from Microsoft [here](https://learn.microsoft.com/en-us/dotnet/cor
 
 1. Download the [latest release]({{ site.otd_release_url }}/OpenTabletDriver.rpm) <small class="text-muted">(OpenTabletDriver.rpm)</small>
 2. Run the following commands in a terminal
+
     ```bash
     # This will install the package
     sudo dnf install ./OpenTabletDriver.rpm
     ```
+
     > This assumes that you are in the directory in which you downloaded OpenTabletDriver to.
 3. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
@@ -44,61 +49,72 @@ Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instru
 
 1. Use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install the `opentabletdriver` AUR package.
 2. Run the following commands in a terminal
-```sh
-# Regenerate initramfs
-sudo mkinitcpio -P
-# Unload kernel modules
-sudo rmmod wacom
-sudo rmmod hid_uclogic
-```
+
+    ```sh
+    # Regenerate initramfs
+    sudo mkinitcpio -P
+    # Unload kernel modules
+    sudo rmmod wacom
+    sudo rmmod hid_uclogic
+    ```
 
 #### `makepkg` method {#manual-makepkg-method}
 
 1. Run the following commands
-```sh
-# Downloads the pkgbuild from the AUR.
-git clone https://aur.archlinux.org/opentabletdriver.git
-# Changes into the correct directory and installs OpenTabletDriver
-cd opentabletdriver && makepkg -si
-# Clean up leftovers
-cd ..
-rm -rf opentabletdriver
-# Regenerate initramfs
-sudo mkinitcpio -P
-# Unload kernel modules
-sudo rmmod wacom
-sudo rmmod hid_uclogic
-```
+
+    ```sh
+    # Downloads the pkgbuild from the AUR.
+    git clone https://aur.archlinux.org/opentabletdriver.git
+    # Changes into the correct directory and installs OpenTabletDriver
+    cd opentabletdriver && makepkg -si
+    # Clean up leftovers
+    cd ..
+    rm -rf opentabletdriver
+    # Regenerate initramfs
+    sudo mkinitcpio -P
+    # Unload kernel modules
+    sudo rmmod wacom
+    sudo rmmod hid_uclogic
+    ```
 
 ### Gentoo {#gentoo}
+
 1. Add Guru overlay
-> This is only required if you don't already have the Guru overlay configured
-```bash
-# Enable guru repository
-sudo eselect repository enable guru
-sudo emerge --sync guru
-```
+
+    > This is only required if you don't already have the Guru overlay configured
+
+    ```bash
+    # Enable guru repository
+    sudo eselect repository enable guru
+    sudo emerge --sync guru
+    ```
 
 2. Edit `/etc/portage/package.accept_keywords` and add this line
-```
-x11-drivers/OpenTabletDriver-bin ~amd64
-```
+
+    ```conf
+    x11-drivers/OpenTabletDriver-bin ~amd64
+    ```
 
 3. Run the following command
-```bash
-# Install the OpenTabletDriver package
-sudo emerge OpenTabletDriver-bin
-```
+
+    ```bash
+    # Install the OpenTabletDriver package
+    sudo emerge OpenTabletDriver-bin
+    ```
 
 4. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
 ### NixOS {#nixos}
+
 1. Edit `/etc/nixos/configuration.nix` and add this in your configuration
-> More configuration options can be found [here](https://search.nixos.org/options?query=opentabletdriver)
-```nix
-# Enable OpenTabletDriver
-hardware.opentabletdriver.enable = true;
-```
+
+    > More configuration options can be found [here](https://search.nixos.org/options?query=opentabletdriver)
+
+    ```nix
+    # Enable OpenTabletDriver
+    hardware.opentabletdriver.enable = true;
+    ```
 
 ### Post-Installation {#post-install}
+
 Take a look at the [FAQ]({% link _wiki/FAQ/Linux.md %}) if you encounter any problems.

--- a/site/_wiki/Install/Windows.md
+++ b/site/_wiki/Install/Windows.md
@@ -18,16 +18,18 @@ directory.
 
 1. Download the [latest release]({{ site.otd_release_url }}/OpenTabletDriver.win-x64.zip). <small class="text-muted">(OpenTabletDriver.win-x64.zip)</small>
 2. Extract the downloaded file into a folder of its own.
-> Replace `<username>` with your username in the example below.
-```
-C:\Users\<username>\OpenTabletDriver
-```
+
+    > Replace `<username>` with your username in the example below.
+
+    `C:\Users\<username>\OpenTabletDriver`
+
 3. Run `OpenTabletDriver.UX.Wpf.exe` in the extracted directory.
-> You can create a shortcut to this file, just make sure that the working directory points
+
+    > You can create a shortcut to this file, just make sure that the working directory points
 to the extracted directory.
 
-
 ### Installation of WinUSB {#winusb}
+
 Some tablets require Zadig's WinUSB installed on a device interface to interact with the tablet correctly. To figure out if your
 tablet requires WinUSB, and if it does, which interface to install it on, carefully check the notes on [the supported list of tablets here]({% link _sections/Tablets.md %}).
 
@@ -40,4 +42,5 @@ tablet requires WinUSB, and if it does, which interface to install it on, carefu
 5. Click `Replace Driver.`
 
 ### Post-Installation {#post-install}
+
 Take a look at the [FAQ]({% link _wiki/FAQ/Windows.md %}) if you encounter any problems.

--- a/site/index.md
+++ b/site/index.md
@@ -1,5 +1,6 @@
 ---
 layout: frontpage
+no_MD041: # avoids MD041, see .markdownlint.yaml
 ---
 
 {{ site.description }}


### PR DESCRIPTION
Lints markdown with [`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli) with the GitHub action [nosborn/github-action-markdown-cli](https://github.com/nosborn/github-action-markdown-cli).

Uses my local fork until a PR is merged that we need: nosborn/github-action-markdown-cli#64

Notes
- ~~Fragments to other pages does not seem to be verified (e.g. `{% link /index.md %}#myid %}`)~~ less of a concern with #76
- Code blocks after `<ol>`'s are not linted for indentation. We can't reasonably lint for this even with a custom rule so I've tried to make sure code blocks are indented correctly with this PR.