### PR TITLE
sections: Permalink to path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,7 @@ defaults:
 collections:
   sections:
     output: true
-    permalink: /:title # intentional uppercase permalink to keep compatility with old website
+    permalink: /:path
   wiki:
     output: true
     permalink: /Wiki/:path # this allows us to use infinitely deep subdirs


### PR DESCRIPTION
This addresses concerns that title must match path

Resolves #37

Interestingly, `:title` in sections _does_ correspond to path (evident by `/Framework` working both before and after despite its title being `Frameworks`), so doing it this way makes it more clear what we're trying to do without actually changing the functionality.

This change affects `_section` endpoints: `/Framework`, `/Plugins` `/Tablets` `/Wiki` but effectively doesn't change them.