### PR TITLE
Simplify body and header whitespace

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark border-bottom border-dark box-shadow mb-3">
+<nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark border-bottom border-dark box-shadow">
   <div class="container d-flex flex-wrap">
     <div class="d-flex flex-row align-items-center flex-grow-1 flex-sm-grow-0 justify-content-between justify-content-sm-start">
       <img src="{% link assets/images/otd.png %}" height="64">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
     {% include styles.html %}
   </head>
   <body data-bs-theme="dark">
-    <header>
+    <header class="mb-3">
       {% include header.html %}
     </header>
     <main role="main" class="container mb-5">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,11 +14,9 @@
     <header>
       {% include header.html %}
     </header>
-    <div class="container">
-      <main role="main" class="pb-3">
-        {{ content }}
-      </main>
-    </div>
+    <main role="main" class="container mb-5">
+      {{ content }}
+    </main>
 
     {% include scripts.html %}
     {% include fix-fouc.html %}

--- a/assets/css/site.scss
+++ b/assets/css/site.scss
@@ -64,11 +64,6 @@ html {
   min-height: 100%;
 }
 
-body {
-  /* Margin bottom by footer height */
-  margin-bottom: 60px;
-}
-
 .table {
   --bs-table-accent-bg: #303030;
 }


### PR DESCRIPTION
Nothing changed visually for the whitespace between body and header, but the end of the body did change. Instead of a hardcoded `60px` bottom margin, it's now using `mb-5`.

Before:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/77161d33-038b-4185-b110-85de2fb3fea7)

After:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/756f1b80-9220-41c8-bc75-6f2bd8209af4)
