### PR TITLE
Add anchor links

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,6 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
 <script src="{% link assets/js/site.js %}"></script>
 <script src="{% link assets/js/markdown-inject.js %}"></script>
+<script src="{% link assets/js/inject-anchors.js %}"></script>

--- a/_layouts/wikipage.html
+++ b/_layouts/wikipage.html
@@ -10,6 +10,6 @@ layout: default
     {% include toc.html html=content id="toc" h_max=3 %}
   </div>
   <div class="col-xs col-sm-8 col-md-9 markdown-content fix-fouc">
-    {{ content | inject_anchors }}
+    {{ content }}
   </div>
 </div>

--- a/_sass/_anchor-blink.scss
+++ b/_sass/_anchor-blink.scss
@@ -1,0 +1,7 @@
+$anchor-blink-color: #88844a;
+
+@keyframes anchor-blink {
+  100% {
+    background-color: rgba($anchor-blink-color, 1);
+  }
+}

--- a/assets/css/site.scss
+++ b/assets/css/site.scss
@@ -4,6 +4,7 @@
 ---
 
 @import "markdown-mixins";
+@import "anchor-blink";
 
 a.navbar-brand {
   white-space: normal;

--- a/assets/js/inject-anchors.js
+++ b/assets/js/inject-anchors.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function(event) {
+  let targets = [
+    '.markdown-content h2',
+    '.markdown-content h3',
+    '.markdown-content h4',
+    '.markdown-content h5',
+  ]
+
+  targets.forEach((target) => {
+    anchors.add(target);
+  });
+});

--- a/assets/js/inject-anchors.js
+++ b/assets/js/inject-anchors.js
@@ -6,6 +6,10 @@ document.addEventListener('DOMContentLoaded', function(event) {
     '.markdown-content h5',
   ]
 
+  anchors.options = {
+    placement: 'left'
+  };
+
   targets.forEach((target) => {
     anchors.add(target);
   });

--- a/assets/js/inject-anchors.js
+++ b/assets/js/inject-anchors.js
@@ -1,4 +1,30 @@
 document.addEventListener('DOMContentLoaded', function(event) {
+  // highlight header first before injecting anchor links to prevent the anchor
+  // links from being destroyed by the highlight function
+  highlightHeader();
+  injectAnchorLinks();
+});
+
+function getAnchor() {
+  let urlParts = document.URL.split('#');
+  return urlParts.length > 1 ? urlParts[1] : null;
+}
+
+function highlightHeader() {
+  let anchor = getAnchor();
+  if (anchor !== null) {
+    let element = document.getElementById(anchor);
+    if (element !== null) {
+      let span = document.createElement('span');
+      span.textContent = element.textContent;
+      span.style.animation = 'anchor-blink 0.25s ease-in-out 0s 4 alternate'
+      element.textContent = '';
+      element.appendChild(span);
+    }
+  }
+}
+
+function injectAnchorLinks() {
   let targets = [
     '.markdown-content h2',
     '.markdown-content h3',
@@ -13,4 +39,4 @@ document.addEventListener('DOMContentLoaded', function(event) {
   targets.forEach((target) => {
     anchors.add(target);
   });
-});
+}


### PR DESCRIPTION
Looks like this on hover:

![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/119b8ca5-a325-48af-80b1-27e58c050dfb)

And looks like this when loading directly via link with anchor:

https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/10338031/51c80b6d-4ce0-4b38-b193-764ac02985cf

I removed jekyll_toc's `inject_anchors` filter since it isn't really working.

- Resolves #50
- Resolves #64