### PR TITLE
README: Update site paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ```bash
 $ gem install jekyll bundler
-$ cd <website root> # (currently git root)
+$ cd site/
 $ git submodule init # submodules contain plugin data
 $ git submodule update
 $ bundle install
@@ -33,7 +33,7 @@ For pages with single-path URLs (e.g., site/Wiki), they are permalinked to files
 To update the Rouge highlighter style, use the following command:
 
 ```bash
-bundle exec rougify style > assets/css/rougehl.css
+bundle exec rougify style > site/assets/css/rougehl.css
 ```
 
 # Contributors to Old OpenTabletDriver.Web


### PR DESCRIPTION
These lines should have been changed with the Jekyll 4.x merge but were forgotten

Fast merging since this is objectively correct