### PR TITLE
README: Adjust local development steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Requirements
 
-- Ruby's [`bundler`](https://bundler.io/)
+- [Ruby](https://www.ruby-lang.org/en/downloads/)
 
 ## Steps
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@
 
 ### Requirements
 
-- `rubygems`
+- Ruby's [`bundler`](https://bundler.io/)
 
 ## Steps
 
 ```bash
-$ gem install jekyll bundler
+$ git submodule update --init # submodules contain plugin metadata
 $ cd site/
-$ git submodule init # submodules contain plugin data
-$ git submodule update
 $ bundle install
 $ bundle exec jekyll serve --livereload
 ```


### PR DESCRIPTION
Modern Ruby installs include Bundler by default, so we technically don't need to advise about rubygems at all.

Improvements are welcome, we could probably even just say that only Ruby is needed, since that is the case?