### PR TITLE
dependabot: Add weekly Bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
 version: 2
 
 updates:
-  - package-ecosystem: gitsubmodule
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
     schedule:
-        interval: "daily"
-    directory: /
+      interval: "daily"
+  - package-ecosystem: "bundler"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
 


### PR DESCRIPTION
Closes #36 

This is similar to running `bundle update --all`, which should be run regularly because bleeding edge is cool (and also puts a bunch of faith in our tests working).