### PR TITLE
config: Use strict filters

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -27,6 +27,9 @@ url: https://opentabletdriver.net # full URI to website
 sass:
   sass_dir: _sass
 
+liquid:
+  strict_filters: true
+
 # Site variables
 latest_otd_version: v0.6.3.0
 


### PR DESCRIPTION
This should allow us to catch use of undefined filters (e.g. `{{ content | toc }}`) at compile time