### PR TITLE
wiki/Logs: Split exception log location into its own section

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           files: .
           dot: true
-          ignore_files: site/_includes/tablets.md # upstream file
+          ignore_files: site/_includes/ # needs special treatment, ignore for now

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For Markdown specifically we use `markdownlint-cli`. Example command:
 
 ```bash
 cd <website root>
-markdownlint --ignore site/vendor/ --ignore site/_data/plugin-repository/ --ignore site/_includes/tablets.md . 2>&1 | less
+markdownlint --ignore site/vendor/ --ignore site/_data/plugin-repository/ --ignore site/_includes/ . 2>&1 | less
 ```
 
 ## Contributors to Old OpenTabletDriver.Web

--- a/site/_includes/appdata-location.md
+++ b/site/_includes/appdata-location.md
@@ -1,0 +1,5 @@
+| Operating System | Path |
+| :--------------: | :--- |
+|      Windows     | `%localappdata%\OpenTabletDriver`
+|       Linux      | `~/.config/OpenTabletDriver`
+|       macOS      | `~/Library/Application Support/OpenTabletDriver`

--- a/site/_wiki/Documentation/Logs.md
+++ b/site/_wiki/Documentation/Logs.md
@@ -8,16 +8,25 @@ To view logs, click on the `Console` tab. Optionally, change filter from `Inform
 
 To export logs, click `Help` -> `Export diagnostics...` in the top menu bar.
 
-Sometimes OpenTabletDriver crashes hard. This is usually caused by a bug in OpenTabletDriver. Due to the crash, it will be impossible to retrieve the logs from GUI. In this case, you can find a partial log in the following locations:
-
-| OS | Location |
-| --- | --- |
-| Windows | `%appdata%\OpenTabletDriver\daemon.log` |
-| Linux | `~/.local/share/OpenTabletDriver/daemon.log` |
-| macOS | `~/Library/Application Support/OpenTabletDriver/daemon.log` |
+Sometimes, the OpenTabletDriver daemon can crash hard enough that the errors can't be
+sent to the GUI. In this case, you can find a
+partial log in the [Exception Log Location](#daemon-log).
 
 ### Daemon
 
 The output from daemon is the log.
 
-On Linux when running daemon via systemd service, the log for daemon is recorded by systemd. To view the log, run `journalctl --user-unit opentabletdriver.service`.
+On Linux when running daemon via systemd service, the log for the daemon is recorded by systemd.
+To view that log, run the following command as your user:
+
+```bash
+journalctl --user-unit opentabletdriver.service
+```
+
+#### Exception Log Location {#daemon-log}
+
+If the daemon crashes from an "unrecoverable" exception, the `daemon.log` file will
+include a stack trace defining where the error happened, which is useful for debugging.
+
+The `daemon.log` file is in the application data folder of OpenTabletDriver.
+The location of which is specified [here]({% link _wiki/FAQ/General.md %}#appdata)

--- a/site/_wiki/Documentation/Logs.md
+++ b/site/_wiki/Documentation/Logs.md
@@ -28,5 +28,9 @@ journalctl --user-unit opentabletdriver.service
 If the daemon crashes from an "unrecoverable" exception, the `daemon.log` file will
 include a stack trace defining where the error happened, which is useful for debugging.
 
-The `daemon.log` file is in the application data folder of OpenTabletDriver.
-The location of which is specified [here]({% link _wiki/FAQ/General.md %}#appdata)
+The `daemon.log` file is in the application data folder, located here:
+
+{% include appdata-location.md %}
+
+> For more details on what else is contained in OpenTabletDriver's application data,
+  see [here]({% link _wiki/FAQ/General.md %}#appdata)

--- a/site/_wiki/Documentation/Logs.md
+++ b/site/_wiki/Documentation/Logs.md
@@ -10,7 +10,7 @@ To export logs, click `Help` -> `Export diagnostics...` in the top menu bar.
 
 Sometimes, the OpenTabletDriver daemon can crash hard enough that the errors can't be
 sent to the GUI. In this case, you can find a
-partial log in the [Exception Log Location](#daemon-log).
+partial log in the location specified [here](#daemon-log).
 
 ### Daemon
 

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -33,11 +33,7 @@ or alternatively, see if there is a [tablet model specific FAQ]({% link _wiki/FA
 
 The following table describes the location of the default application data directory for each operating system:
 
-| Operating System | Path |
-| :--------------: | :--- |
-|      Windows     | `%localappdata%\OpenTabletDriver`
-|       Linux      | `~/.config/OpenTabletDriver`
-|       macOS      | `~/Library/Application Support/OpenTabletDriver`
+{% include appdata-location.md %}
 
 The application data directory contents are as follows:
 


### PR DESCRIPTION
Old:
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/421345/19ceb3fb-966b-4236-bca8-112607f72e25)

New:
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/421345/589b90c4-9f90-43b6-85be-ca574e8a545e)