### PR TITLE
wiki refactor: Rewrite tables

### DIFF
--- a/site/_wiki/Development/Configurations.md
+++ b/site/_wiki/Development/Configurations.md
@@ -7,9 +7,9 @@ title: Writing OpenTabletDriver Configurations
 Generic device identification information is required for OpenTabletDriver in order for it to be able to differentiate
 tablets.
 
-|  Property Name   |   Value Type   | Description                                                                                                                                      |
-|:----------------:|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------|
-|       Name       |    `string`    | The name of the device. This is always the device manufacturer's name followed by the device's model number or product name when not applicable. |
+|  Property Name   |   Value Type   | Description |
+| :--------------: | :------------: | :---------- |
+|       Name       |    `string`    | The name of the device. This is always the device manufacturer's name followed by the device's model number or product name when not applicable.
 
 ### Specifications
 
@@ -21,31 +21,31 @@ accurately handle the data the tablet device outputs.
 This refers to the graphics tablet's digitizer, which provides coordinates of where the tool is positioned. This is
 always required for the device to function.
 
-|     Property Name     | Value Type |    Units     | Description                                                 |
-|:---------------------:|:----------:|:------------:|:------------------------------------------------------------|
-|         Width         |  `double`  |      mm      | The physical width of the digitizer in millimeters.         |
-|        Height         |  `double`  |      mm      | The physical height of the digitizer in millimeters.        |
-| Horizontal Resolution |  `double`  | Device Units | The horizontal resolution of the digitizer in device units. |
-|  Vertical Resolution  |  `double`  | Device Units | The vertical resolution of the digitizer in device units.   |
+|     Property Name     | Value Type |    Units     | Description |
+| :-------------------: | :--------: | :----------: | :---------- |
+|         Width         |  `double`  |      mm      | The physical width of the digitizer in millimeters
+|        Height         |  `double`  |      mm      | The physical height of the digitizer in millimeters
+| Horizontal Resolution |  `double`  | Device Units | The horizontal resolution of the digitizer in device units
+|  Vertical Resolution  |  `double`  | Device Units | The vertical resolution of the digitizer in device units
 
 #### Pen
 
 This refers to the pen tool for the graphics tablet. It is the source of position and typically the source of pressure
 data. This is almost always required.
 
-|  Property Name  | Value Type | Description                                                                                                                                                                                                                   |
-|:---------------:|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  Max Pressure   |   `uint`   | The maximum pressure reported by the pen in device pressure units. This is used to calculate a percentage of pressure. If there are more than pens supported by this tablet, the pen with the highest pressure value is used. |
-|  Button Count   |   `uint`   | The amount of buttons on the pen. This does not include the eraser, if applicable. If there are more than one pens supported by this tablet, use the number of buttons on the pen with the most.                              |
+|  Property Name  | Value Type | Description |
+| :-------------: | :--------: | :---------- |
+|  Max Pressure   |   `uint`   | The maximum pressure reported by the pen in device pressure units. This is used to calculate a percentage of pressure. If there are more than pens supported by this tablet, the pen with the highest pressure value is used.
+|  Button Count   |   `uint`   | The amount of buttons on the pen. This does not include the eraser, if applicable. If there are more than one pens supported by this tablet, use the number of buttons on the pen with the most.
 
 #### Auxiliary Buttons
 
 This refers to any buttons located on the graphics tablet pad. This should only be enabled if there are any auxililary
 buttons.
 
-| Property Name | Value Type  | Description            |
-|:-------------:|:-----------:|:-----------------------|
-| Button Count  |   `uint`    | The amount of buttons. |
+| Property Name | Value Type  | Description |
+| :-----------: | :---------: | :---------- |
+| Button Count  |   `uint`    | The amount of buttons
 
 #### Touch
 
@@ -66,19 +66,22 @@ This has the same properties as the [auxiliary buttons](#auxiliary-buttons)
 Device identifiers are what actually detect the tablet. Anything defined here is used in the detection process to
 pinpoint devices.
 
-|         Property Name         |         Value Type         | Description                                                                                                                                                                                                                                                                                                                                 |
-|:-----------------------------:|:--------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|           Vendor ID           |          `ushort`          | A USB-IF defined identifier that defines which vendor the device is produced by. Since this is assigned by the USB-IF it can be quite reliable for determining the manufacturer.                                                                                                                                                            |
-|          Product ID           |          `ushort`          | A vendor-defined identifier for the device. This can be used to identify a device, however this can be unreliable as it depends on the vendor defining it different for all of their devices.                                                                                                                                               |
-|      Input Report Length      |          `ushort`          | The length of input reports from the device. This is always required as report parsers expect a specific report length.                                                                                                                                                                                                                     |
-|     Output Report Length      |          `ushort`          | The length of output reports to the device endpoint. This is not always required, however it does help make the detection more precise.                                                                                                                                                                                                     |
-|         Report Parser         |          `string`          | The parser that will read and convert all tablet report data into a format that OpenTabletDriver understands. This is the full namespace and the class name. All supported vendor-specific report parsers can be found [here](https://github.com/OpenTabletDriver/OpenTabletDriver/tree/HEAD/OpenTabletDriver.Configurations/Parsers) |
-| Feature Initialization Report |       `List<byte[]>`       | A list of feature reports to be sent to the device to perform the device's initialization sequence.                                                                                                                                                                                                                                         |
-| Output Initialization Report  |       `List<byte[]>`       | A list of output reports to be sent to the device to perform the device's initialization sequence.                                                                                                                                                                                                                                          |
-|        Device Strings         | `Dictionary<byte, string>` | A list of regular expressions to be matched against specific indexes of strings contained within the device's firmware. They can be retrieved via the device string reader. This is optional, however it is commonly used to improve detection precision.                                                                                   |
-| Initialization String Indexes |          `byte[]`          | A list of indexes to be retrieved from the device as part of the device's initialization sequence. This is optional, and very infrequently used. |
+|         Property Name         |         Value Type         | Description |
+| :---------------------------: | :------------------------: | :---------- |
+|           Vendor ID           |          `ushort`          | A [USB-IF] defined identifier that defines which vendor the device is produced by. Since this is assigned by the USB-IF it can be quite reliable for determining the manufacturer.
+|          Product ID           |          `ushort`          | A vendor-defined identifier for the device. This can be used to identify a device, however this can be unreliable as it depends on the vendor defining it different for all of their devices.
+|      Input Report Length      |          `ushort`          | The length of input reports from the device. This is always required as report parsers expect a specific report length.
+|     Output Report Length      |          `ushort`          | The length of output reports to the device endpoint. This is not always required, however it does help make the detection more precise.
+|         Report Parser         |          `string`          | The parser that will read and convert all tablet report data into a format that OpenTabletDriver understands. This is the full namespace and the class name. All supported vendor-specific report parsers can be found [here][parsers].
+| Feature Initialization Report |       `List<byte[]>`       | A list of feature reports to be sent to the device to perform the device's initialization sequence.
+| Output Initialization Report  |       `List<byte[]>`       | A list of output reports to be sent to the device to perform the device's initialization sequence.
+|        Device Strings         | `Dictionary<byte, string>` | A list of regular expressions to be matched against specific indexes of strings contained within the device's firmware. They can be retrieved via the device string reader. This is optional, however it is commonly used to improve detection precision.
+| Initialization String Indexes |          `byte[]`          | A list of indexes to be retrieved from the device as part of the device's initialization sequence. This is optional, and very infrequently used.
 
 > Byte arrays (`byte[]`) are serialized as Base64 in JSON.NET, the library that serializes and deserializes configurations.
+
+[USB-IF]: https://en.wikipedia.org/wiki/USB_Implementers_Forum "USB Implementers Forum"
+[parsers]: https://github.com/OpenTabletDriver/OpenTabletDriver/tree/HEAD/OpenTabletDriver.Configurations/Parsers
 
 ### Attributes
 

--- a/site/_wiki/Documentation/CommandLine.md
+++ b/site/_wiki/Documentation/CommandLine.md
@@ -6,16 +6,16 @@ title: Command Line
 
 #### UI
 
-| Argument | Description |
-| --- | --- |
-| `--minimized` or `-m` | Starts the application in a minimized state |
+|        Argument       | Description |
+| :-------------------: | ----------- |
+| `--minimized` or `-m` | Starts the application in a minimized state
 
 #### Daemon
 
-| Argument | Description |
-| --- | --- |
-| `--appdata` or `-a` | Uses the specified directory for application data |
-| `--config` or `-c` | Uses the specified directory for searching of tablet configuration overrides |
+|       Argument      | Description |
+| :-----------------: | ----------- |
+| `--appdata` or `-a` | Uses the specified directory for application data
+| `--config` or `-c`  | Uses the specified directory for searching of tablet configuration overrides
 
 #### Console
 

--- a/site/_wiki/Documentation/RequiredPermissions.md
+++ b/site/_wiki/Documentation/RequiredPermissions.md
@@ -74,10 +74,10 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 Then update the initramfs:
 
-| Distro | Command |
-| --- | --- |
-| Arch Linux | `sudo mkinitcpio -P` |
-| Debian/Ubuntu | `sudo update-initramfs -u` |
+|    Distro     | Command |
+| :-----------: | :------ |
+|  Arch Linux   | `sudo mkinitcpio -P`
+| Debian/Ubuntu | `sudo update-initramfs -u`
 
 For other distros, refer to your distro's documentation on how to update the initramfs.
 
@@ -121,10 +121,10 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 Then update the initramfs:
 
-| Distro | Command |
-| --- | --- |
-| Arch Linux | `sudo mkinitcpio -P` |
-| Debian/Ubuntu | `sudo update-initramfs -u` |
+|    Distro     | Command |
+| :-----------: | :------ |
+|  Arch Linux   | `sudo mkinitcpio -P`
+| Debian/Ubuntu | `sudo update-initramfs -u`
 
 For other distros, refer to your distro's documentation on how to update the initramfs.
 

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -34,22 +34,22 @@ or alternatively, see if there is a [tablet model specific FAQ]({% link _wiki/FA
 The following table describes the location of the default application data directory for each operating system:
 
 | Operating System | Path |
-| --- | --- |
-| Windows | `%localappdata%\OpenTabletDriver` |
-| Linux | `~/.config/OpenTabletDriver` |
-| macOS | `~/Library/Application Support/OpenTabletDriver` |
+| :--------------: | :--- |
+|      Windows     | `%localappdata%\OpenTabletDriver`
+|       Linux      | `~/.config/OpenTabletDriver`
+|       macOS      | `~/Library/Application Support/OpenTabletDriver`
 
-Its contents are as follows:
+The application data directory contents are as follows:
 
-| Entry | Type | Description |
-| --- | --- | --- |
-| `settings.json` | File | Stores the driver settings |
-| `tablet-data.txt` | File | Stores the recorded tablet data from Tablet Debugger |
-| `daemon.log` | File | Contains a stack trace when daemon crashes |
-| Backup | Directory | Contains backups of OpenTabletDriver binaries and settings triggered by updates |
-| Cache | Directory | Contains cached Github data for fast browsing within Plugin Manager |
-| Plugins | Directory | Contains plugins. This should not be manually modified unless you know what you're doing |
-| Presets | Directory | Contains saved presets |
+|       Entry       |  Type  | Description |
+| :---------------: | :----: | :---------- |
+|  `settings.json`  |  File  | Stores the driver settings
+| `tablet-data.txt` |  File  | Stores the recorded tablet data from Tablet Debugger
+|   `daemon.log`    |  File  | Contains a stack trace if the daemon has crashed
+|      Backup       | Folder | Contains old versions of OpenTabletDriver and its settings
+|       Cache       | Folder | Contains cached metadata for the Plugin Manager
+|      Plugins      | Folder | Contains installed plugins (`.dll` files). This folder should not be modified manually.
+|      Presets      | Folder | Contains saved presets
 
 ### My cursor is going crazy! It teleports everywhere! {#emi-interference}
 
@@ -90,26 +90,30 @@ Uninstall any other tablet drivers you have installed.
 
 #### Conversion through manual calculation
 
-| Term | Definition |
-| --- | --- |
-| Width | The width of the area in millimeters |
-| Height | The height of the area in millimeters |
-| TWidth | The width of the tablet's digitizer in millimeters. Can be found in tablet's configuration file |
-| THeight | The height of the tablet's digitizer in millimeters. Can be found in the tablet's configuration file |
-| XOffset | The X offset of the center of the area in millimeters |
-| YOffset | The Y offset of the center of the area in millimeters |
-| LPI | Lines per inch, this is commonly 5080 or 2540 |
+Use this reference chart for the upcoming formulas:
+
+|  Term   | Definition |
+| :-----: | :--------- |
+|  Width  | The width of the area in millimeters
+| Height  | The height of the area in millimeters
+| TWidth  | The width of the tablet's digitizer in millimeters. Can be found in the tablet's configuration file.
+| THeight | The height of the tablet's digitizer in millimeters. Can be found in the tablet's configuration file.
+| XOffset | The X offset of the center of the area in millimeters
+| YOffset | The Y offset of the center of the area in millimeters
+|   LPI   | Lines per inch, this is commonly 5080 or 2540
+
+`TWidth` and `THeight` can be found in the tablet's configuration file.
 
 Use the following formulas to get values for the area editor's `Width`, `Height`, `XOffset`, and `YOffset` fields.
 
 ##### Wacom and Veikk
 
-| Term | Definition |
-| --- | --- |
-| Left | The number of lines from the left side of the tablet to the left side of the area |
-| Top | The number of lines from the top side of the tablet to the top side of the area |
-| Right | The number of lines from the left side of the tablet to the right side of the area |
-| Bottom | The number of lines from the top side of the tablet to the bottom side of the area |
+|  Term  | Definition |
+| :----: | :--------- |
+|  Left  | The number of lines from the left side of the tablet to the left side of the area
+|  Top   | The number of lines from the top side of the tablet to the top side of the area
+| Right  | The number of lines from the left side of the tablet to the right side of the area
+| Bottom | The number of lines from the top side of the tablet to the bottom side of the area
 
 Formula:
 
@@ -123,11 +127,11 @@ YOffset = (Top / LPI * 25.4) + (Height / 2)
 ##### XP-Pen
 
 | Term | Definition |
-| --- | --- |
-| XPW | The width in XP-Pen units. Denoted as `W` in XP-Pen's official drivers |
-| XPH | The height in XP-Pen units. Denoted as `H` in XP-Pen's official drivers |
-| XPX | The X offset of the top left corner of the area in XP-Pen units. Denoted as `X` in XP-Pen's official drivers |
-| XPY | The Y offset of the top left corner of the area in XP-Pen units. Denoted as `Y` in XP-Pen's official drivers |
+| :--: | :--------- |
+| XPW  | The width in XP-Pen units. Denoted as `W` in XP-Pen's official drivers.
+| XPH  | The height in XP-Pen units. Denoted as `H` in XP-Pen's official drivers.
+| XPX  | The X offset of the top left corner of the area in XP-Pen units. Denoted as `X` in XP-Pen's official drivers.
+| XPY  | The Y offset of the top left corner of the area in XP-Pen units. Denoted as `Y` in XP-Pen's official drivers.
 
 Formula:
 
@@ -140,12 +144,12 @@ YOffset = (Height / 2) + (XPY / 3.937)
 
 ##### Huion and Gaomon
 
-| Term | Definition |
-| --- | --- |
-| Left | The percentage of the distance from the left side of the tablet to the left side of the area |
-| Top | The percentage of the distance from the top side of the tablet to the top side of the area |
-| Right | The percentage of the distance from the left side of the tablet to the right side of the area |
-| Bottom | The percentage of the distance from the top side of the tablet to the bottom side of the area |
+|  Term  | Definition |
+| :----: | --- |
+|  Left  | The percentage of the distance from the left side of the tablet to the left side of the area
+|  Top   | The percentage of the distance from the top side of the tablet to the top side of the area
+| Right  | The percentage of the distance from the left side of the tablet to the right side of the area
+| Bottom | The percentage of the distance from the top side of the tablet to the bottom side of the area
 
 Formula:
 


### PR DESCRIPTION
Use center-aligned tables, except for last attribute which is left-aligned