### PR TITLE
workflows: Restrict actions push conditions to just 'main'

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -3,6 +3,7 @@ name: Jekyll CI
 on:
   workflow_dispatch:
   push:
+    branches: ["main"]
   pull_request:
 jobs:
   build:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,6 +3,7 @@ name: Linting
 on:
   workflow_dispatch:
   push:
+    branches: ["main"]
   pull_request:
 jobs:
   editorconfig:


### PR DESCRIPTION
Not having it is causing PR tests to temporarily show a failed test, as the Jekyll build needs to be on a site with Github Pages active.

Put differently, any push (even on forks) would result in the Jekyll workflow failing. We could leave the Linter workflow untouched, but it is changed for consistency in case the Linter workflow is expanded in scope.

Also fixes #121