### PR TITLE
inject-anchors: Refactor and enable blink on 'hashchange'

### DIFF
--- a/site/assets/js/inject-anchors.js
+++ b/site/assets/js/inject-anchors.js
@@ -14,7 +14,7 @@ function highlightHeader(anchor) {
   }
 
   let element = document.querySelector('#' + anchor + ' > span');
-  if (element !== null) {
+  if (element !== null && element.style.animation === '') {
     element.style.animation = 'anchor-blink ' + duration + 's ease-in-out 0s ' +
       iterations + ' alternate';
 

--- a/site/assets/js/inject-anchors.js
+++ b/site/assets/js/inject-anchors.js
@@ -18,7 +18,7 @@ function highlightHeader() {
 
   let anchor = getAnchor();
   if (anchor !== null) {
-    let element = document.getElementById(anchor);
+    let element = document.querySelector('#' + anchor + ' > span');
     if (element !== null) {
       element.style.animation = 'anchor-blink ' + duration + 's ease-in-out 0s ' +
         iterations + ' alternate';
@@ -44,6 +44,27 @@ function injectAnchorLinks() {
   };
 
   targets.forEach((target) => {
+    // add anchor links
     anchors.add(target);
+
+    // rewrite header's child nodes to wrap the textContent inside a span block.
+    // this is to run the animation on the text without the header's padding
+    document.querySelectorAll(target).forEach((target) => {
+      let headerAnchor = target.querySelector("a.anchorjs-link");
+      let span = document.createElement('span');
+      span.textContent = target.textContent;
+      span.style.display = 'block';
+
+      removeAllChildNodes(target);
+
+      target.appendChild(headerAnchor);
+      target.appendChild(span);
+    });
   });
+}
+
+function removeAllChildNodes(parent) {
+    while (parent.firstChild) {
+        parent.removeChild(parent.firstChild);
+    }
 }

--- a/site/assets/js/inject-anchors.js
+++ b/site/assets/js/inject-anchors.js
@@ -1,33 +1,27 @@
 document.addEventListener('DOMContentLoaded', (event) => {
   injectAnchorLinks();
-  highlightHeader();
+
+  // blink on load when an anchor exists in URL
+  highlightHeader(getAnchor(document.URL));
 });
 
-window.addEventListener('hashchange', (event) => {
-  highlightHeader();
-});
-
-function getAnchor() {
-  let urlParts = document.URL.split('#');
-  return urlParts.length > 1 ? urlParts[1] : null;
-}
-
-function highlightHeader() {
+function highlightHeader(anchor) {
   let duration = 0.25; // animation duration in seconds
   let iterations = 4; // number of times animation is run
 
-  let anchor = getAnchor();
-  if (anchor !== null) {
-    let element = document.querySelector('#' + anchor + ' > span');
-    if (element !== null) {
-      element.style.animation = 'anchor-blink ' + duration + 's ease-in-out 0s ' +
-        iterations + ' alternate';
+  if (anchor === null) {
+    return;
+  }
 
-      // unset after animation has run to allow multiple animations per page visit
-      setTimeout(function() {
-        element.style.animation = '';
-      }, duration * iterations * 1000);
-    }
+  let element = document.querySelector('#' + anchor + ' > span');
+  if (element !== null) {
+    element.style.animation = 'anchor-blink ' + duration + 's ease-in-out 0s ' +
+      iterations + ' alternate';
+
+    // unset after animation has run to allow multiple animations per page visit
+    setTimeout(function() {
+      element.style.animation = '';
+    }, duration * iterations * 1000);
   }
 }
 
@@ -43,8 +37,8 @@ function injectAnchorLinks() {
     placement: 'left'
   };
 
+  // add anchor links for each headers
   targets.forEach((target) => {
-    // add anchor links
     anchors.add(target);
 
     // rewrite header's child nodes to wrap the textContent inside a span block.
@@ -61,6 +55,20 @@ function injectAnchorLinks() {
       target.appendChild(span);
     });
   });
+
+  // blink on click on toc
+  let toc = document.getElementById('toc');
+  toc.querySelectorAll('li > a').forEach((tocEntry) => {
+    tocEntry.addEventListener('click', (event) => {
+      let anchor = getAnchor(tocEntry.getAttribute('href'));
+      highlightHeader(anchor);
+    });
+  });
+}
+
+function getAnchor(input) {
+  let parts = input.split('#');
+  return parts.length > 1 ? parts[1] : null;
 }
 
 function removeAllChildNodes(parent) {

--- a/site/assets/js/inject-anchors.js
+++ b/site/assets/js/inject-anchors.js
@@ -1,12 +1,11 @@
-document.addEventListener('DOMContentLoaded', injectHandler);
-window.addEventListener('hashchange', injectHandler);
-
-let __InjectedAnchors = false;
-
-function injectHandler(event) {
-  highlightHeader();
+document.addEventListener('DOMContentLoaded', (event) => {
   injectAnchorLinks();
-}
+  highlightHeader();
+});
+
+window.addEventListener('hashchange', (event) => {
+  highlightHeader();
+});
 
 function getAnchor() {
   let urlParts = document.URL.split('#');
@@ -33,11 +32,6 @@ function highlightHeader() {
 }
 
 function injectAnchorLinks() {
-  if (__InjectedAnchors)
-    return;
-
-  __InjectedAnchors = true;
-
   let targets = [
     '.markdown-content h2',
     '.markdown-content h3',

--- a/site/assets/js/inject-anchors.js
+++ b/site/assets/js/inject-anchors.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', (event) => {
   highlightHeader(getAnchor(document.URL));
 });
 
+let __animatingElement = null;
+
 function highlightHeader(anchor) {
   let duration = 0.25; // animation duration in seconds
   let iterations = 4; // number of times animation is run
@@ -15,6 +17,12 @@ function highlightHeader(anchor) {
 
   let element = document.querySelector('#' + anchor + ' > span');
   if (element !== null && element.style.animation === '') {
+    // stop animating previous element
+    if (__animatingElement !== null && __animatingElement !== element) {
+      __animatingElement.style.animation = null;
+    }
+    __animatingElement = element;
+
     element.style.animation = 'anchor-blink ' + duration + 's ease-in-out 0s ' +
       iterations + ' alternate';
 

--- a/site/assets/js/inject-anchors.js
+++ b/site/assets/js/inject-anchors.js
@@ -1,9 +1,12 @@
-document.addEventListener('DOMContentLoaded', function(event) {
-  // highlight header first before injecting anchor links to prevent the anchor
-  // links from being destroyed by the highlight function
+document.addEventListener('DOMContentLoaded', injectHandler);
+window.addEventListener('hashchange', injectHandler);
+
+let __InjectedAnchors = false;
+
+function injectHandler(event) {
   highlightHeader();
   injectAnchorLinks();
-});
+}
 
 function getAnchor() {
   let urlParts = document.URL.split('#');
@@ -11,20 +14,30 @@ function getAnchor() {
 }
 
 function highlightHeader() {
+  let duration = 0.25; // animation duration in seconds
+  let iterations = 4; // number of times animation is run
+
   let anchor = getAnchor();
   if (anchor !== null) {
     let element = document.getElementById(anchor);
     if (element !== null) {
-      let span = document.createElement('span');
-      span.textContent = element.textContent;
-      span.style.animation = 'anchor-blink 0.25s ease-in-out 0s 4 alternate'
-      element.textContent = '';
-      element.appendChild(span);
+      element.style.animation = 'anchor-blink ' + duration + 's ease-in-out 0s ' +
+        iterations + ' alternate';
+
+      // unset after animation has run to allow multiple animations per page visit
+      setTimeout(function() {
+        element.style.animation = '';
+      }, duration * iterations * 1000);
     }
   }
 }
 
 function injectAnchorLinks() {
+  if (__InjectedAnchors)
+    return;
+
+  __InjectedAnchors = true;
+
   let targets = [
     '.markdown-content h2',
     '.markdown-content h3',


### PR DESCRIPTION
This also changes the behavior of the animation to span the entire block, rather than rewriting the block text to a span, and then animating the span.

This is an intentional stylistic change since I felt the previous method was not obvious enough.

This also fixes animations 'eating' the anchor link

Fixes #72