### PR TITLE
Cache busting CSS/JS using a query string

### DIFF
--- a/site/_includes/scripts.html
+++ b/site/_includes/scripts.html
@@ -1,6 +1,6 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
-<script src="{% link assets/js/site.js %}"></script>
-<script src="{% link assets/js/markdown-inject.js %}"></script>
-<script src="{% link assets/js/inject-anchors.js %}"></script>
+<script src="{% asset /js/site.js %}"></script>
+<script src="{% asset /js/markdown-inject.js %}"></script>
+<script src="{% asset /js/inject-anchors.js %}"></script>

--- a/site/_includes/styles.html
+++ b/site/_includes/styles.html
@@ -1,4 +1,4 @@
 <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-<link rel="stylesheet" href="{% link assets/css/rougehl.css %}">
-<link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
-<link rel="stylesheet" href="{% link assets/css/fix-fouc.css %}">
+<link rel="stylesheet" href="{% asset /css/rougehl.css %}">
+<link rel="stylesheet" href="{% scssasset /css/site.scss %}">
+<link rel="stylesheet" href="{% asset /css/fix-fouc.css %}">

--- a/site/_plugins/get-asset.rb
+++ b/site/_plugins/get-asset.rb
@@ -1,0 +1,40 @@
+require 'digest'
+
+# renders the requested path with a hash appended to the query string to help bust caches
+
+class GetCacheBustedAsset < Liquid::Tag
+  @@BASEPATH = "assets"
+  @@HASHLENGTH = 16
+  @@COMPATIBLE_TAGS = [ "scssasset", "asset" ]
+
+  def initialize(tag_name, assetPath, tokens)
+    super
+
+    raise "Relative paths are not supported" unless assetPath[0] == "/"
+
+    assetPath = assetPath.strip # remove trailing space
+
+    @assetPath = File.join(@@BASEPATH,assetPath)
+    raise "Invalid file '%s'" % @assetPath unless File.exist? @assetPath
+
+    @hash = Digest::SHA256.hexdigest(File.read(@assetPath))[0,@@HASHLENGTH]
+
+    if tag_name == "scssasset"
+      @assetPath = @assetPath.strip.gsub(/\.scss$/, ".css")
+    end
+
+    raise "Unknown tag '%s'" % tag_name unless @@COMPATIBLE_TAGS.include? tag_name
+  end
+
+  def render(context)
+    return "/%s?%s" % [@assetPath, @hash]
+  end
+
+  def self.get_tags()
+    return @@COMPATIBLE_TAGS
+  end
+end
+
+GetCacheBustedAsset.get_tags().each do |tag|
+  Liquid::Template.register_tag(tag, GetCacheBustedAsset)
+end


### PR DESCRIPTION
This helps avoid caches incorrectly returning "304 Not Changed". Some brief testing seems to indicate that query strings does correctly cause a cache hit on our webserver (Cloudflare?)

We can also consider moving the hosting (haha) to something like Cloudflare Pages which allows us to control HTTP headers.

This solution isn't optimal, we should be using a Jekyll hook to change the filename and the defined path in the HTML, since caching on query strings is not clearly defined across caching proxies.