### PR TITLE
js/inject-anchors: Only on wiki pages

### DIFF
--- a/site/_includes/scripts.html
+++ b/site/_includes/scripts.html
@@ -3,4 +3,3 @@
 <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
 <script src="{% asset /js/site.js %}"></script>
 <script src="{% asset /js/markdown-inject.js %}"></script>
-<script src="{% asset /js/inject-anchors.js %}"></script>

--- a/site/_layouts/wikipage.html
+++ b/site/_layouts/wikipage.html
@@ -14,4 +14,5 @@ layout: default
   <div class="col-xs col-sm-9 markdown-content fix-fouc">
     {{ content }}
   </div>
+  <script src="{% asset /js/inject-anchors.js %}"></script>
 </div>


### PR DESCRIPTION
This functionality is not used outside of wiki pages