### PR TITLE
`/Plugins`: Add noscript support, and reduce jarringness of plugins' JS sort

### DIFF
--- a/site/_layouts/plugins.html
+++ b/site/_layouts/plugins.html
@@ -4,7 +4,7 @@ layout: default
 
 {% assign plugins = "" | split: ',' %}
 <div class="container">
-  <div class="d-flex mb-3">
+  <div id="searchblock" class="d-flex mb-3">
     <div class="flex-fill">
       <div class="form-floating me-3">
         <input type="text" class="form-control" id="searchInput" placeholder="Search" onkeyup="filterInput()"/>
@@ -41,8 +41,14 @@ layout: default
       </div>
     </div>
   </div>
+  <noscript>
+    <style>#searchblock { display: none !important; }</style>
+    <div id="noscriptblock" class="d-flex mb-3">
+      {{ content }}
+    </div>
+  </noscript>
 
-  <div id="metadataList">
+  <div id="metadataList" class="fix-fouc">
     {% assign plugins = plugins | sort: "Name" %}
     {%- for metadata in plugins -%}
       {% assign supportedDriverVersionSplit = metadata.SupportedDriverVersion | split: '.' %}

--- a/site/_sections/Plugins.md
+++ b/site/_sections/Plugins.md
@@ -2,3 +2,5 @@
 title: Plugins
 layout: plugins
 ---
+
+It looks like you have JavaScript disabled! You are shown the full suite of plugins:


### PR DESCRIPTION
This hides the search boxes for noscript users as they only have a function with JavaScript. Additionally, we inform the user when JavaScript is disabled.

Technically fixes #91 but I'm not sure if this is the desired fix (flashing the list in from nothing instead of cards disappearing after sort)

Here's what it looks like with Javascript disabled on this page:
![image](https://github.com/OpenTabletDriver/opentabletdriver.github.io/assets/421345/f5b9e6ef-b362-4149-9109-d88afb68c6cf)
