### PR TITLE
markdownlint: Reenable MD028

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -62,7 +62,6 @@ MD013: false
 # MD027: Multiple spaces after blockquote
 
 # MD028: Blank line inside blockquote
-MD028: false
 
 # MD029: Ordered list item prefix
 MD029:


### PR DESCRIPTION
Fixes #143

As usual with linting changes, being more strict ensures cleaner looking code.