### PR TITLE
Add EndeavourOS install instructions

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,8 @@
 {
-  "Exclude": ["\\.md$", "Gemfile.lock$", "assets/css/rougehl.css$"]
+  "Exclude": [ "\\.md$",
+    "Gemfile.lock$",
+    "assets/css/rougehl.css$",
+    "_includes/wiki/arch-makepkg-commands.txt",
+    "_includes/wiki/arch-regen-commands.txt"
+  ]
 }

--- a/site/_includes/wiki/arch-install-steps.md
+++ b/site/_includes/wiki/arch-install-steps.md
@@ -3,8 +3,8 @@
 {% assign includeMakepkgSteps = include.makepkg | default: false %}
 
     ```sh
-    {% if includeMakepkgSteps -%}
-        {% include wiki/arch-makepkg-steps.txt %}
-    {%- endif -%}
-    {% include wiki/arch-regen-commands.txt -%}
+   {% if includeMakepkgSteps -%}
+       {% include wiki/arch-makepkg-commands.txt %}
+   {%- endif -%}
+   {% include wiki/arch-regen-commands.txt -%}
     ```

--- a/site/_includes/wiki/arch-install-steps.md
+++ b/site/_includes/wiki/arch-install-steps.md
@@ -1,0 +1,10 @@
+{% assign ramdiskUpdateCommand = include.ramdisk_update_command | default: "mkinitcpio -P" %}
+{% assign elevateCommand = include.elevate_command | default: "sudo" %}
+{% assign includeMakepkgSteps = include.makepkg | default: false %}
+
+    ```sh
+    {% if includeMakepkgSteps -%}
+        {% include wiki/arch-makepkg-steps.txt %}
+    {%- endif -%}
+    {% include wiki/arch-regen-commands.txt -%}
+    ```

--- a/site/_includes/wiki/arch-makepkg-commands.txt
+++ b/site/_includes/wiki/arch-makepkg-commands.txt
@@ -1,4 +1,4 @@
-# Downloads the pkgbuild from the AUR.
+ # Downloads the pkgbuild from the AUR.
  git clone https://aur.archlinux.org/opentabletdriver.git
  # Changes into the correct directory, pulls needed dependencies, then installs OpenTabletDriver
  cd opentabletdriver && makepkg -si

--- a/site/_includes/wiki/arch-makepkg-steps.txt
+++ b/site/_includes/wiki/arch-makepkg-steps.txt
@@ -1,0 +1,7 @@
+# Downloads the pkgbuild from the AUR.
+ git clone https://aur.archlinux.org/opentabletdriver.git
+ # Changes into the correct directory, pulls needed dependencies, then installs OpenTabletDriver
+ cd opentabletdriver && makepkg -si
+ # Clean up leftovers
+ cd ..
+ rm -rf opentabletdriver

--- a/site/_includes/wiki/arch-regen-commands.txt
+++ b/site/_includes/wiki/arch-regen-commands.txt
@@ -1,0 +1,4 @@
+ # Regenerate initramfs
+ {{ elevateCommand }} {{ ramdiskUpdateCommand }}
+ # Unload kernel modules
+ {{ elevateCommand }} rmmod wacom hid_uclogic

--- a/site/_wiki/Install/Linux.md
+++ b/site/_wiki/Install/Linux.md
@@ -68,6 +68,24 @@ If you're experiencing `libhostfxr` issues, please see the solutions from Micros
 
 4. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
 
+## EndeavoursOS {#endeavouros}
+
+While EndeavourOS is based on Arch Linux, it uses a different initramfs
+generator compared to standard Arch Linux, which means the post-install setup is different.
+
+1. Install the `opentabletdriver` AUR package with either the GUI package utility, Pamac,
+   or the command-line utility, `yay`
+
+    ```sh
+    yay -S opentabletdriver
+    ```
+
+2. Then, run the following commands in a terminal
+
+{% include wiki/arch-install-steps.md ramdisk_update_command="dracut-rebuild" %}
+
+Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.
+
 ## Arch Linux {#arch}
 
 You can install OpenTabletDriver from the AUR. There are two ways to do this.
@@ -86,30 +104,13 @@ Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instru
 1. Use an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) to install the `opentabletdriver` AUR package.
 2. Run the following commands in a terminal
 
-    ```sh
-    # Regenerate initramfs
-    sudo mkinitcpio -P
-    # Unload kernel modules
-    sudo rmmod wacom hid_uclogic
-    ```
+{% include wiki/arch-install-steps.md %}
 
 ### `makepkg` method {#manual-makepkg-method}
 
 1. Run the following commands in a terminal
 
-    ```sh
-    # Downloads the pkgbuild from the AUR.
-    git clone https://aur.archlinux.org/opentabletdriver.git
-    # Changes into the correct directory, pulls needed dependencies, then installs OpenTabletDriver
-    cd opentabletdriver && makepkg -si
-    # Clean up leftovers
-    cd ..
-    rm -rf opentabletdriver
-    # Regenerate initramfs
-    sudo mkinitcpio -P
-    # Unload kernel modules
-    sudo rmmod wacom hid_uclogic
-    ```
+{% include wiki/arch-install-steps.md makepkg=true %}
 
 ## Gentoo {#gentoo}
 


### PR DESCRIPTION
I've also split the Arch install steps into includes. This reduces the amount of duplicated text in the repository, and allows us to easier support other variants of Arch Linux.

Helps with some concerns in #93 but does not fix it entirely.

<img width="861" height="1427" alt="Screenshot 2025-10-03 at 18-27-24 Linux Installation Guide - OpenTabletDriver" src="https://github.com/user-attachments/assets/6fc54a72-098a-4da6-8c3f-918c3f3f38ea" />