### PR TITLE
Import SCSS from gems

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -17,6 +17,10 @@ group :jekyll_plugins do
   gem 'jekyll-github-metadata', '~> 2.16'
 end
 
+gem 'json'
+gem "bootswatch", github: "thomaspark/bootswatch", branch: "v5"
+gem "bootstrap", "~> 5.3.2"
+
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -1,23 +1,39 @@
+GIT
+  remote: https://github.com/thomaspark/bootswatch.git
+  revision: 36b93e93619a7c23654b80f053adc5aaf81b1c6a
+  branch: v5
+  specs:
+    bootswatch (5.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    base64 (0.2.0)
+    autoprefixer-rails (10.4.16.0)
+      execjs (~> 2)
+    bootstrap (5.3.2)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.11.8, < 3)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.8.1)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    execjs (2.9.1)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.1-x86_64-linux)
+    google-protobuf (3.25.2)
+    google-protobuf (3.25.2-aarch64-linux)
+    google-protobuf (3.25.2-arm64-darwin)
+    google-protobuf (3.25.2-x86-linux)
+    google-protobuf (3.25.2-x86_64-darwin)
+    google-protobuf (3.25.2-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -44,6 +60,7 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.7.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -53,40 +70,87 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    net-http (0.4.1)
+      uri
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    popper_js (2.11.8)
     public_suffix (5.0.4)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (4.2.0)
-    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.6-x86_64-linux-gnu)
-      google-protobuf (~> 3.25)
+    sass-embedded (1.69.5-aarch64-linux-android)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-aarch64-linux-gnu)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-aarch64-linux-musl)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm-linux-androideabi)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm-linux-gnueabihf)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm-linux-musleabihf)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm64-darwin)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86-linux-android)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86-linux-gnu)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86-linux-musl)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-darwin)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-linux-android)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-linux-gnu)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-linux-musl)
+      google-protobuf (~> 3.23)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     webrick (1.8.1)
 
 PLATFORMS
-  x86_64-linux
+  aarch64-linux
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnueabihf
+  arm-linux-musleabihf
+  arm64-darwin
+  x86-linux
+  x86-linux-android
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
+  bootstrap (~> 5.3.2)
+  bootswatch!
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.3)
   jekyll-github-metadata (~> 2.16)
+  json
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)
   webrick (~> 1.8)
 
 BUNDLED WITH
-   2.4.21
+   2.5.4

--- a/site/_includes/styles.html
+++ b/site/_includes/styles.html
@@ -1,4 +1,3 @@
-<link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 <link rel="stylesheet" href="{% asset /css/rougehl.css %}">
 <link rel="stylesheet" href="{% scssasset /css/site.scss %}">
 <link rel="stylesheet" href="{% asset /css/fix-fouc.css %}">

--- a/site/_includes/styles.html
+++ b/site/_includes/styles.html
@@ -1,3 +1,3 @@
-<link rel="stylesheet" href="{% asset /css/rougehl.css %}">
 <link rel="stylesheet" href="{% scssasset /css/site.scss %}">
+<link rel="stylesheet" href="{% asset /css/rougehl.css %}">
 <link rel="stylesheet" href="{% asset /css/fix-fouc.css %}">

--- a/site/_plugins/inject-scss-gems.rb
+++ b/site/_plugins/inject-scss-gems.rb
@@ -1,0 +1,15 @@
+require 'rubygems'
+require 'bootstrap'
+
+Jekyll::Hooks.register :site, :after_init do |site|
+  # Ensure 'load_paths' is initialized
+  site.config["sass"]["load_paths"] = [] if site.config["sass"]["load_paths"].nil?
+
+  # Add Bootstrap stylesheets path
+  site.config["sass"]["load_paths"] << Bootstrap.stylesheets_path
+
+  # Add Bootswatch stylesheets path
+  Gem.loaded_specs["bootswatch"].load_paths.each do |path|
+    site.config["sass"]["load_paths"] << path
+  end
+end

--- a/site/assets/css/site.scss
+++ b/site/assets/css/site.scss
@@ -3,6 +3,10 @@
 # only Main files contain this front matter, not partials.
 ---
 
+@import "darkly/variables";
+@import "_bootstrap";
+@import "darkly/bootswatch";
+
 @import "markdown-mixins";
 @import "anchor-blink";
 


### PR DESCRIPTION
This will help keeping the stylesheets updated, and allows us some flexibility in customizing the SCSS further.

Only downsides are that we lose CDN caching for our stylesheets, and build times will be slightly longer.

Slight side effect of this PR is that I also add `json` as a Gem and the `Gemfile.lock` file is updated to the latest Bundler version.