### PR TITLE
Refactor SCSS

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -17,6 +17,10 @@ group :jekyll_plugins do
   gem 'jekyll-github-metadata', '~> 2.16'
 end
 
+gem 'json'
+gem "bootswatch", github: "thomaspark/bootswatch", branch: "v5"
+gem "bootstrap", "~> 5.3.2"
+
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/thomaspark/bootswatch.git
-  revision: 36b93e93619a7c23654b80f053adc5aaf81b1c6a
+  revision: 0b64b984923ed0eb373aed9cf1bb8e697c30847a
   branch: v5
   specs:
-    bootswatch (5.3.2)
+    bootswatch (5.3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -28,14 +28,14 @@ GEM
       net-http
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.2)
-    google-protobuf (3.25.2-aarch64-linux)
-    google-protobuf (3.25.2-arm64-darwin)
-    google-protobuf (3.25.2-x86-linux)
-    google-protobuf (3.25.2-x86_64-darwin)
-    google-protobuf (3.25.2-x86_64-linux)
+    google-protobuf (3.25.3)
+    google-protobuf (3.25.3-aarch64-linux)
+    google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86-linux)
+    google-protobuf (3.25.3-x86_64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
     http_parser.rb (0.8.0)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     jekyll (4.3.3)
       addressable (~> 2.4)
@@ -66,7 +66,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -1,23 +1,39 @@
+GIT
+  remote: https://github.com/thomaspark/bootswatch.git
+  revision: 36b93e93619a7c23654b80f053adc5aaf81b1c6a
+  branch: v5
+  specs:
+    bootswatch (5.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    base64 (0.2.0)
+    autoprefixer-rails (10.4.16.0)
+      execjs (~> 2)
+    bootstrap (5.3.2)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.11.8, < 3)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.8.1)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    execjs (2.9.1)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.1-x86_64-linux)
+    google-protobuf (3.25.2)
+    google-protobuf (3.25.2-aarch64-linux)
+    google-protobuf (3.25.2-arm64-darwin)
+    google-protobuf (3.25.2-x86-linux)
+    google-protobuf (3.25.2-x86_64-darwin)
+    google-protobuf (3.25.2-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -44,6 +60,7 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.7.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -53,40 +70,87 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    net-http (0.4.1)
+      uri
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    popper_js (2.11.8)
     public_suffix (5.0.4)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (4.2.0)
-    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.6-x86_64-linux-gnu)
-      google-protobuf (~> 3.25)
+    sass-embedded (1.69.5-aarch64-linux-android)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-aarch64-linux-gnu)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-aarch64-linux-musl)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm-linux-androideabi)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm-linux-gnueabihf)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm-linux-musleabihf)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-arm64-darwin)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86-linux-android)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86-linux-gnu)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86-linux-musl)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-darwin)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-linux-android)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-linux-gnu)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-linux-musl)
+      google-protobuf (~> 3.23)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     webrick (1.8.1)
 
 PLATFORMS
-  x86_64-linux
+  aarch64-linux
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnueabihf
+  arm-linux-musleabihf
+  arm64-darwin
+  x86-linux
+  x86-linux-android
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
+  bootstrap (~> 5.3.2)
+  bootswatch!
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.3)
   jekyll-github-metadata (~> 2.16)
+  json
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)
   webrick (~> 1.8)
 
 BUNDLED WITH
-   2.4.21
+   2.5.4

--- a/site/_includes/appdata-location.md
+++ b/site/_includes/appdata-location.md
@@ -3,3 +3,4 @@
 |      Windows     | `%localappdata%\OpenTabletDriver`
 |       Linux      | `~/.config/OpenTabletDriver`
 |       macOS      | `~/Library/Application Support/OpenTabletDriver`
+{: .table .table-dark }

--- a/site/_includes/styles.html
+++ b/site/_includes/styles.html
@@ -1,4 +1,3 @@
-<link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 <link rel="stylesheet" href="{% asset /css/rougehl.css %}">
 <link rel="stylesheet" href="{% scssasset /css/site.scss %}">
 <link rel="stylesheet" href="{% asset /css/fix-fouc.css %}">

--- a/site/_includes/styles.html
+++ b/site/_includes/styles.html
@@ -1,3 +1,3 @@
-<link rel="stylesheet" href="{% asset /css/rougehl.css %}">
 <link rel="stylesheet" href="{% scssasset /css/site.scss %}">
+<link rel="stylesheet" href="{% asset /css/rougehl.css %}">
 <link rel="stylesheet" href="{% asset /css/fix-fouc.css %}">

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -10,7 +10,7 @@
     {%- endif -%}
     {% include styles.html %}
   </head>
-  <body data-bs-theme="dark">
+  <body>
     <header class="mb-4">
       {% include header.html %}
     </header>

--- a/site/_layouts/tablets.html
+++ b/site/_layouts/tablets.html
@@ -11,7 +11,7 @@ layout: default
   </div>
 
   {% capture tablets %}
-{% include tablets.md %}{: #tablets .table .table-hover }
+{% include tablets.md %}{: #tablets .table .table-hover .table-dark }
   {% endcapture %}
   {{ tablets | markdownify }}
 

--- a/site/_plugins/inject-scss-gems.rb
+++ b/site/_plugins/inject-scss-gems.rb
@@ -1,0 +1,15 @@
+require 'rubygems'
+require 'bootstrap'
+
+Jekyll::Hooks.register :site, :after_init do |site|
+  # Ensure 'load_paths' is initialized
+  site.config["sass"]["load_paths"] = [] if site.config["sass"]["load_paths"].nil?
+
+  # Add Bootstrap stylesheets path
+  site.config["sass"]["load_paths"] << Bootstrap.stylesheets_path
+
+  # Add Bootswatch stylesheets path
+  Gem.loaded_specs["bootswatch"].load_paths.each do |path|
+    site.config["sass"]["load_paths"] << path
+  end
+end

--- a/site/_wiki/Development/Configurations.md
+++ b/site/_wiki/Development/Configurations.md
@@ -10,6 +10,7 @@ tablets.
 |  Property Name   |   Value Type   | Description |
 | :--------------: | :------------: | :---------- |
 |       Name       |    `string`    | The name of the device. This is always the device manufacturer's name followed by the device's model number or product name when not applicable.
+{: .table .table-dark }
 
 ## Specifications
 
@@ -27,6 +28,7 @@ always required for the device to function.
 |        Height         |  `double`  |      mm      | The physical height of the digitizer in millimeters
 | Horizontal Resolution |  `double`  | Device Units | The horizontal resolution of the digitizer in device units
 |  Vertical Resolution  |  `double`  | Device Units | The vertical resolution of the digitizer in device units
+{: .table .table-dark }
 
 ### Pen
 
@@ -37,6 +39,7 @@ data. This is almost always required.
 | :-------------: | :--------: | :---------- |
 |  Max Pressure   |   `uint`   | The maximum pressure reported by the pen in device pressure units. This is used to calculate a percentage of pressure. If there are more than pens supported by this tablet, the pen with the highest pressure value is used.
 |  Button Count   |   `uint`   | The amount of buttons on the pen. This does not include the eraser, if applicable. If there are more than one pens supported by this tablet, use the number of buttons on the pen with the most.
+{: .table .table-dark }
 
 ### Auxiliary Buttons
 
@@ -46,6 +49,7 @@ buttons.
 | Property Name | Value Type  | Description |
 | :-----------: | :---------: | :---------- |
 | Button Count  |   `uint`    | The amount of buttons
+{: .table .table-dark }
 
 ### Touch
 
@@ -77,6 +81,7 @@ pinpoint devices.
 | Output Initialization Report  |       `List<byte[]>`       | A list of output reports to be sent to the device to perform the device's initialization sequence.
 |        Device Strings         | `Dictionary<byte, string>` | A list of regular expressions to be matched against specific indexes of strings contained within the device's firmware. They can be retrieved via the device string reader. This is optional, however it is commonly used to improve detection precision.
 | Initialization String Indexes |          `byte[]`          | A list of indexes to be retrieved from the device as part of the device's initialization sequence. This is optional, and very infrequently used.
+{: .table .table-dark }
 
 > Byte arrays (`byte[]`) are serialized as Base64 in JSON.NET, the library that serializes and deserializes configurations.
 {:.alert-primary}
@@ -99,6 +104,7 @@ Some example attributes include:
 |    `WinInterface`    |       [00..99]       | *(Windows only)* Similar to `MacInterface`. String must have exactly two digits, (e.g. `"01"`)
 |      `WinUsage`      |       [00..99]       | *(Windows only)* Specifies the HID usage collection to use. String must have exactly two digits (e.g. `"01"`)
 | `FeatureInitDelayMs` |     milliseconds     | For tablets with multiple feature initialization reports (e.g. polling rate change), wait this many milliseconds between reports. This can help if later feature initialization reports are sometimes randomly not picked up by the tablet.
+{: .table .table-dark }
 
 [libinput]: https://www.freedesktop.org/wiki/Software/libinput/ "freedesktop.org's site on libinput"
 [udev]: https://wiki.debian.org/udev

--- a/site/_wiki/Documentation/CommandLine.md
+++ b/site/_wiki/Documentation/CommandLine.md
@@ -7,6 +7,7 @@ title: Command Line Arguments
 |        Argument       | Description |
 | :-------------------: | ----------- |
 | `--minimized` or `-m` | Starts the application in a minimized state
+{: .table .table-dark }
 
 ## Daemon
 
@@ -14,6 +15,7 @@ title: Command Line Arguments
 | :-----------------: | ----------- |
 | `--appdata` or `-a` | Uses the specified directory for application data
 | `--config` or `-c`  | Uses the specified directory for searching of tablet configuration overrides
+{: .table .table-dark }
 
 ## Console
 
@@ -26,3 +28,4 @@ Use the `--help` argument to see the list of supported commands in your specific
 | :----------------------: | ----------- |
 |        `--version`       | Shows the compatible OpenTabletDriver daemon version
 | `--help` or `-h` or `-?` | Shows the available commands for use with the console application
+{: .table .table-dark }

--- a/site/_wiki/Documentation/RequiredPermissions.md
+++ b/site/_wiki/Documentation/RequiredPermissions.md
@@ -87,6 +87,7 @@ Then update the initramfs:
 | :-----------: | :------ |
 |  Arch Linux   | `sudo mkinitcpio -P`
 | Debian/Ubuntu | `sudo update-initramfs -u`
+{: .table .table-dark }
 
 For other distros, refer to your distro's documentation on how to update the initramfs.
 
@@ -135,6 +136,7 @@ Then update the initramfs:
 | :-----------: | :------ |
 |  Arch Linux   | `sudo mkinitcpio -P`
 | Debian/Ubuntu | `sudo update-initramfs -u`
+{: .table .table-dark }
 
 For other distros, refer to your distro's documentation on how to update the initramfs.
 
@@ -164,6 +166,7 @@ OpenTabletDriver requires the following permissions:
 | :--------------: | :----------------- |
 |  Accessibility   | To move the cursor
 | Input Monitoring | To read the current cursor position and properly send relative movements (relative mode)
+{: .table .table-dark }
 
 To grant this, navigate to <kbd>Settings</kbd> ⇒ <kbd>System Preferences</kbd> ⇒ <kbd>Security and Privacy</kbd> ⇒ <kbd>Privacy</kbd>, then check the permissions required.
 

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -46,6 +46,7 @@ The application data directory contents are as follows:
 |       Cache       | Folder | Contains cached metadata for the Plugin Manager
 |      Plugins      | Folder | Contains installed plugins (`.dll` files). This folder should not be modified manually.
 |      Presets      | Folder | Contains saved presets
+{: .table .table-dark }
 
 ## My cursor is going crazy! It teleports everywhere! {#emi-interference}
 
@@ -88,6 +89,7 @@ However, to make the driver output the pressure to your operating system, you ma
 |      Windows     | [Windows Ink] | A virtual device driver (VMulti) and the Windows Ink plugin is needed
 |       Linux      | [Artist Mode] | Built-in, simply change the output mode of OpenTabletDriver
 |       MacOS      |  unsupported  | This is a work in progress, and is expected with the 0.7 release of OpenTabletDriver
+{: .table .table-dark }
 
 [Windows Ink]: {% link _wiki/FAQ/Windows.md %}#win-ink
 [Artist Mode]: {% link _wiki/FAQ/Linux.md %}#artist-mode
@@ -113,6 +115,7 @@ Use this reference chart for the upcoming formulas:
 | XOffset | The X offset of the center of the area in millimeters
 | YOffset | The Y offset of the center of the area in millimeters
 |   LPI   | Lines per inch, this is commonly 5080 or 2540
+{: .table .table-dark }
 
 `TWidth` and `THeight` can be found in the tablet's configuration file.
 
@@ -126,6 +129,7 @@ Use the following formulas to get values for OpenTabletDriver's area editor's `W
 |  Top   | The number of lines from the top side of the tablet to the top side of the area
 | Right  | The number of lines from the left side of the tablet to the right side of the area
 | Bottom | The number of lines from the top side of the tablet to the bottom side of the area
+{: .table .table-dark }
 
 **Formula**:
 
@@ -144,6 +148,7 @@ YOffset = (Height / 2) + (Top  / LPI * 25.4)
 | XPH  | The height in XP-Pen units. Denoted as `H` in XP-Pen's official drivers.
 | XPX  | The X offset of the top left corner of the area in XP-Pen units. Denoted as `X` in XP-Pen's official drivers.
 | XPY  | The Y offset of the top left corner of the area in XP-Pen units. Denoted as `Y` in XP-Pen's official drivers.
+{: .table .table-dark }
 
 **Formula**:
 
@@ -162,6 +167,7 @@ YOffset = (Height / 2) + (XPY / 3.937)
 |  Top   | The percentage of the distance from the top side of the tablet to the top side of the area
 | Right  | The percentage of the distance from the left side of the tablet to the right side of the area
 | Bottom | The percentage of the distance from the top side of the tablet to the bottom side of the area
+{: .table .table-dark }
 
 **Formula**:
 

--- a/site/assets/css/site.scss
+++ b/site/assets/css/site.scss
@@ -4,134 +4,74 @@
 ---
 
 @import "darkly/variables";
+$color-mode-type: media-query;
 @import "_bootstrap";
 @import "darkly/bootswatch";
 
 @import "markdown-mixins";
 @import "anchor-blink";
 
+// nav title ("OpenTabletDriver")
 a.navbar-brand {
   white-space: normal;
   text-align: center;
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background */
-a {
-  color: #0366d6;
-}
-
-.btn-primary {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
-}
-
-.nav-pills .nav-link.active, .nav-pills .show > .nav-link {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
-}
-
-/* Sticky footer styles
--------------------------------------------------- */
-html {
-  font-size: 14px;
-}
-
-@media (min-width: 768px) {
-  html {
-    font-size: 16px;
-  }
-}
-
-.border-top {
-  border-top: 1px solid #e5e5e5;
-}
-
-.border-bottom {
-  border-bottom: 1px solid #e5e5e5;
-}
-
+// used in <nav>
 .box-shadow {
   box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
 }
 
-button.accept-policy {
-  font-size: 1rem;
-  line-height: inherit;
-}
-
-/* Sticky footer styles
--------------------------------------------------- */
-html {
-  position: relative;
-  min-height: 100%;
-}
-
-.table {
-  --bs-table-accent-bg: #303030;
-}
-
+// used with Tablets table description
 .dropmargins {
   margin: 0;
 }
 
-#toc a {
-  color:#c4cfda;
-  text-decoration: none;
-}
-
-#toc a:focus,
-#toc a:hover {
-  color:#bdc4ca;
-}
-
+// Table of Contents, e.g. on Wiki pages
 #toc {
   margin-top: 0.8em;
   padding-left: 1em;
+
+  a {
+    text-decoration: none;
+  }
+
+  ul {
+    padding-left: 1.5em;
+  }
+
+  li {
+    padding-left: 1ex;
+  }
 }
 
-#toc ul {
-  padding-left: 1.5em;
-}
-
-#toc li {
-  padding-left: 1ex;
-}
-
+// <li>'s get too packed without this
 li {
-  margin-top: 6px;
-  margin-bottom: 6px;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
 }
 
+// parsed code blocks that has syntax highlighting
 div.highlighter-rouge {
   margin-top: 1em;
   margin-bottom: 1em;
-}
 
-div.highlighter-rouge pre.highlight {
-  padding: 1em;
+  pre.highlight {
+    padding: 1em;
+  }
 }
 
 #page-title {
   @include markdown-header;
-  font-size: calc(1.375em + 1.5vw);
-}
-
-@media (min-width: 1200px) {
-  #page-title {
-    font-size: 2.5rem;
-  }
 }
 
 #toc-container {
-  visibility: collapse;
-}
-
-#toc-container > div {
-  position: sticky;
-  top: 1.5em;
+  visibility: collapse; // hide on smaller devices (see later media rules)
+  > div {
+    position: sticky; // always keep in view
+    top: 1.5em; // spacing from top when sticky is acting
+  }
 }
 
 @media (min-width: 576px) {
@@ -140,61 +80,44 @@ div.highlighter-rouge pre.highlight {
   }
 }
 
-@media (min-width: 576px) {
-  .markdown-content {
-    padding-left: 2em;
-  }
-}
-
 .markdown-content {
   h2 {
-    font-size: 1.55em;
     counter-increment: h2-section;
+    > span::before {
+      content: counter(h2-section) ".";
+    }
   }
+
   h3 {
-    font-size: 1.45em;
     counter-increment: h3-section;
     ~ h2 {
       counter-reset: h3-section;
     }
+    > span::before {
+      content: counter(h2-section) "." counter(h3-section) ".";
+    }
   }
+
   h4 {
-    font-size: 1.28em;
     counter-increment: h4-section;
     ~ h3 {
       counter-reset: h4-section;
     }
-  }
-  h5 {
-    font-size: 1.16em;
-  }
-  h6 {
-    font-size: 1em;
-  }
-
-  h2 > span::before {
-    content: counter(h2-section) "."
-  }
-
-  h3 > span::before {
-    content: counter(h2-section) "." counter(h3-section) "."
-  }
-
-  h4 > span::before {
-    content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) "."
+    > span::before {
+      content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) ".";
+    }
   }
 
   h2, h3 {
-    @include markdown-header
+    @include markdown-header;
   }
 
-  h2 > span::before,
-  h3 > span::before,
-  h4 > span::before,
-  h5 > span::before {
-    color:#c0c0c0;
-    font-style: italic;
-    margin-right: 1ex;
+  h2, h3, h4, h5 {
+    // counter display
+    > span::before {
+      font-style: italic;
+      margin-right: 1ex;
+    }
   }
 }
 
@@ -203,30 +126,30 @@ div.highlighter-rouge pre.highlight {
   &::marker {
     content: counter(h2-section) ".";
   }
-}
 
-#toc > li > ul > li {
-  counter-increment: h3-section;
-  &::marker {
-    content: counter(h2-section) "." counter(h3-section) ".";
-  }
-  &:last-child {
-    counter-reset: h3-section;
-  }
-}
+  > ul > li {
+    counter-increment: h3-section;
+    &::marker {
+      content: counter(h2-section) "." counter(h3-section) ".";
+    }
+    &:first-child {
+      counter-reset: h3-section;
+    }
 
-#toc > li > ul > li > ul > li {
-  counter-increment: h4-section;
-  &::marker {
-    content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) ".";
-  }
-  &:last-child {
-    counter-reset: h4-section;
+    > ul > li {
+      counter-increment: h4-section;
+      &::marker {
+        content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) ".";
+      }
+      &:first-child {
+        counter-reset: h4-section;
+      }
+    }
   }
 }
 
 .markdown-content blockquote > p:last-child {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .alert-compact {

--- a/site/assets/css/site.scss
+++ b/site/assets/css/site.scss
@@ -3,6 +3,10 @@
 # only Main files contain this front matter, not partials.
 ---
 
+@import "darkly/variables";
+@import "_bootstrap";
+@import "darkly/bootswatch";
+
 @import "markdown-mixins";
 @import "anchor-blink";
 


### PR DESCRIPTION
Darkly is still a predominantly dark-theme skin, but has small variations between dark and light mode.

A lot of color and pixel-specific settings have been removed as the stock theme is actually surprisingly close what we want.
Additionally, having these was hindering correct light/dark mode display.
Removing these also allows us to be more flexible with which Bootswatch themes we can use.

Many definitions have been moved around to better fit the nesting of SCSS, reducing clutter and
increasing readability.

Supersedes #157
Supersedes #154
Fixes #33
Fixes #151