### PR TITLE
Use better maintained source opentabletdriver gentoo package

### DIFF
--- a/site/_wiki/Install/Linux.md
+++ b/site/_wiki/Install/Linux.md
@@ -120,13 +120,13 @@ Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instru
 2. Edit `/etc/portage/package.accept_keywords` and add this line
 
     ```conf
-    x11-drivers/OpenTabletDriver-bin ~amd64
+    x11-drivers/OpenTabletDriver ~amd64
     ```
 
 3. Install the package with the following command
 
     ```bash
-    sudo emerge OpenTabletDriver-bin
+    sudo emerge OpenTabletDriver
     ```
 
 4. Refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instructions on how to auto-start OpenTabletDriver on boot.


### PR DESCRIPTION
A source package now exists for OpenTabletDriver on gentoo, it is in a much better state, uses the latest version of OTD,  the scripts are updated, etc etc.

I haven't personally tested these instructions but considering that it still uses the keyword these instructions should work.

The only "problem" I see here is that its a different maintainer, which maybe we should note somewhere?

Also even on systemd no systemd service is provided (on both packages), so we should probably relink the section to point directly at the other init systems section or place a note elsewhere. Not a biggie though.

Here is a link to the new package: https://github.com/gentoo/guru/tree/master/x11-drivers/OpenTabletDriver