### PR TITLE
Wiki/Linux: Simplify `rmmod` commands

### DIFF
--- a/site/_wiki/Documentation/RequiredPermissions.md
+++ b/site/_wiki/Documentation/RequiredPermissions.md
@@ -29,11 +29,10 @@ Currently, two kernel modules are also unloaded as they interfere with OpenTable
 A kernel module blacklist is used to prevent these modules from loading on boot.
 
 If you've just installed OpenTabletDriver, make sure these
-modules aren't loaded by running the following commands:
+modules aren't loaded by running the following command:
 
 ```sh
-sudo rmmod wacom
-sudo rmmod hid_uclogic
+sudo rmmod wacom hid_uclogic
 ```
 
 ### Set up udev rules and kernel module blacklist {#setup-linux}
@@ -73,8 +72,7 @@ if [ -f /etc/modprobe.d/blacklist.conf ]; then
 fi
 
 sudo modprobe uinput
-sudo rmmod wacom > /dev/null 2>&1
-sudo rmmod hid_uclogic > /dev/null 2>&1
+sudo rmmod wacom hid_uclogic > /dev/null 2>&1
 
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
@@ -124,8 +122,7 @@ cd ..
 rm -rf OpenTabletDriver
 
 sudo modprobe uinput
-sudo rmmod wacom > /dev/null 2>&1
-sudo rmmod hid_uclogic > /dev/null 2>&1
+sudo rmmod wacom hid_uclogic > /dev/null 2>&1
 
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```

--- a/site/_wiki/Install/Linux.md
+++ b/site/_wiki/Install/Linux.md
@@ -82,8 +82,7 @@ Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instru
     # Regenerate initramfs
     sudo mkinitcpio -P
     # Unload kernel modules
-    sudo rmmod wacom
-    sudo rmmod hid_uclogic
+    sudo rmmod wacom hid_uclogic
     ```
 
 ### `makepkg` method {#manual-makepkg-method}
@@ -101,8 +100,7 @@ Then refer to [this section]({% link _wiki/FAQ/Linux.md %}#autostart) for instru
     # Regenerate initramfs
     sudo mkinitcpio -P
     # Unload kernel modules
-    sudo rmmod wacom
-    sudo rmmod hid_uclogic
+    sudo rmmod wacom hid_uclogic
     ```
 
 ## Gentoo {#gentoo}


### PR DESCRIPTION
This ensures that the user actually unloads all driver modules, in case only 1 of the 2 commands was run

Fixes #164 