### PR TITLE
Add apple verification error to macos faq

### DIFF
--- a/site/_wiki/FAQ/MacOS.md
+++ b/site/_wiki/FAQ/MacOS.md
@@ -7,6 +7,10 @@ hide_from_auto_list: true
 first before continuing.
 {:.alert-primary}
 
+## Apple could not verify "OpenTabletDriver" {#apple-verification}
+
+Follow the steps in [Apple's Documentation](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac) for your MacOS version.
+
 ## Cursor doesn't respond to tablet input {#cursor-not-moving}
 
 See [here]({% link _wiki/Documentation/RequiredPermissions.md %}#macos).


### PR DESCRIPTION
It is possible to hit an error like this when trying to open OTD:

![image](https://github.com/user-attachments/assets/0ecaff8d-a132-42fe-b472-24fd828ec42c)

Apple has official docs for resolving this so we can link there. Apple has pages for other variants of this error but they require the exact same steps.