### PR TITLE
Mention required permissions in macos install

### DIFF
--- a/site/_wiki/Install/MacOS.md
+++ b/site/_wiki/Install/MacOS.md
@@ -8,6 +8,7 @@ hide_from_auto_list: true
 1. Download the [latest release]({{ site.data.links.project.latestRelease.osx-x64 }}) <small class="text-muted">(OpenTabletDriver.osx-x64.tar.gz)</small>
 2. Extract it and drag `{% otdexe macos-extractor %}` into your Applications folder
 3. Run the OpenTabletDriver app.
+4. Set up the [required permissions](https://opentabletdriver.net/Wiki/Documentation/RequiredPermissions#macos).
 
 ## Post-installation {#post-install}
 

--- a/site/_wiki/Install/MacOS.md
+++ b/site/_wiki/Install/MacOS.md
@@ -8,7 +8,7 @@ hide_from_auto_list: true
 1. Download the [latest release]({{ site.data.links.project.latestRelease.osx-x64 }}) <small class="text-muted">(OpenTabletDriver.osx-x64.tar.gz)</small>
 2. Extract it and drag `{% otdexe macos-extractor %}` into your Applications folder
 3. Run the OpenTabletDriver app.
-4. Set up the [required permissions](https://opentabletdriver.net/Wiki/Documentation/RequiredPermissions#macos).
+4. Set up the [required permissions]({% link _wiki/Documentation/RequiredPermissions.md %}#macos).
 
 ## Post-installation {#post-install}
 


### PR DESCRIPTION
This should always be required so it makes sense to mention it in the main install guide rather than only in the faq. The permissions can be concerning to some users so it's better to put it upfront rather than make the user dig around for it.