### PR TITLE
Change GIMP 2.99 to GIMP 3 for windows app specific

### DIFF
--- a/site/_wiki/FAQ/WindowsAppSpecific.md
+++ b/site/_wiki/FAQ/WindowsAppSpecific.md
@@ -93,7 +93,7 @@ UseSystemStylus 1
 
 ### GIMP
 
-Use GIMP 2.99 to have Windows Ink support. GIMP 2.10 and below does not support Windows Ink.
+Use GIMP 3 to have Windows Ink support. GIMP 2.10 and below does not support Windows Ink.
 
 ### FireAlpaca
 


### PR DESCRIPTION
Now that GIMP has moved on from calling GIMP 3 dev builds "GIMP 2.99" and instead has release candidate builds (GIMP 3.0 RCx) it makes sense to note GIMP 3 here.