### PR TITLE
CSS counter support for h5 and h6

### DIFF
--- a/site/assets/css/site.scss
+++ b/site/assets/css/site.scss
@@ -124,7 +124,8 @@ div.highlighter-rouge {
       counter-reset: h5-section;
     }
     > span::before {
-      content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) "." counter(h5-section) ".";
+      content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) "."
+          counter(h5-section) ".";
     }
   }
   h6 {
@@ -134,7 +135,8 @@ div.highlighter-rouge {
       counter-reset: h6-section;
     }
     > span::before {
-      content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) "." counter(h5-section) "." counter(h6-section) ".";
+      content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) "."
+          counter(h5-section) "." counter(h6-section) ".";
     }
   }
 

--- a/site/assets/css/site.scss
+++ b/site/assets/css/site.scss
@@ -119,9 +119,23 @@ div.highlighter-rouge {
   }
   h5 {
     font-size: 1.16em;
+    counter-increment: h5-section;
+    ~ h4 {
+      counter-reset: h5-section;
+    }
+    > span::before {
+      content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) "." counter(h5-section) ".";
+    }
   }
   h6 {
     font-size: 1em;
+    counter-increment: h6-section;
+    ~ h5 {
+      counter-reset: h6-section;
+    }
+    > span::before {
+      content: counter(h2-section) "." counter(h3-section) "." counter(h4-section) "." counter(h5-section) "." counter(h6-section) ".";
+    }
   }
 
   h2, h3 {

--- a/site/assets/css/site.scss
+++ b/site/assets/css/site.scss
@@ -142,7 +142,7 @@ div.highlighter-rouge {
     @include markdown-header;
   }
 
-  h2, h3, h4, h5 {
+  h2, h3, h4, h5, h6 {
     // counter display
     > span::before {
       font-style: italic;

--- a/site/assets/js/inject-anchors.js
+++ b/site/assets/js/inject-anchors.js
@@ -39,6 +39,7 @@ function injectAnchorLinks() {
     '.markdown-content h3',
     '.markdown-content h4',
     '.markdown-content h5',
+    '.markdown-content h6',
   ]
 
   anchors.options = {


### PR DESCRIPTION
Counters weren't working with H5's and H6's, this PR fixes that. H5 fix needed in #173 to fix styling.