### PR TITLE
Install/Linux: Adjust Debian and Fedora file names

### DIFF
--- a/site/_wiki/Install/Linux.md
+++ b/site/_wiki/Install/Linux.md
@@ -32,11 +32,13 @@ If you're experiencing `libhostfxr` issues, please see the solutions from Micros
 
 ### Fedora {#fedora}
 
-1. {% include latest-release.html filename=site.data.links.project.latestRelease.rpm %}
+{% assign rpm_filename = site.data.links.project.latestRelease.rpm | replace: '{{VERSION}}', latest_otd_version %}
+
+1. {% include latest-release.html filename=rpm_filename %}
 2. Install the package with the following command:
 
     ```bash
-    sudo dnf install ./OpenTabletDriver.rpm
+    sudo dnf install ./{{ rpm_filename }}
     ```
 
     > This assumes that you are in the directory in which you downloaded OpenTabletDriver to.


### PR DESCRIPTION
Fixes #288

# Pre-PR:

- Debian install step:
```sh
# Install the package
sudo apt install ./opentabletdriver-{{VERSION}}-1-x64.deb
```

- Fedora install step:
```sh
sudo dnf install ./OpenTabletDriver.rpm
```

# Post-PR

- Debian install step:
```sh
# Install the package
sudo apt install ./opentabletdriver-0.6.6.0-1-x64.deb
```

- Fedora install step:
```sh
sudo dnf install ./opentabletdriver-0.6.6.0-1.x86_64.rpm
```