### PR TITLE
HTML Proofer: Ignore status code 418

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,10 @@ task :htmlproofer do
     # /Plugins.html can misbehave here in case of GitHub README.md anchors
     #     because of User-Agent handling, and changing User-Agent causes other
     #     unwanted side effects
-    check_external_hash: false
+    check_external_hash: false,
+    # status code 418 is sometimes returned by webservers performing anti-scrape methods, so it
+    # should assume the resource exists instead
+    ignore_status_codes: [ 418 ],
   }
 
   HTMLProofer.check_directory(compiledSitePath, options).run


### PR DESCRIPTION
https://www.freedesktop.org/wiki/Software/libinput currently returns 418 for HTTP clients that aren't confirmed to be real humans - this commit ignores this status as an error

Fixes a false-negative check