### PR TITLE
Note photoshop incompatibilities and bump year

### DIFF
--- a/site/_wiki/FAQ/WindowsAppSpecific.md
+++ b/site/_wiki/FAQ/WindowsAppSpecific.md
@@ -69,6 +69,9 @@ No need to restart the application.
 
 ### Photoshop CC
 
+> Photoshop versions prior to CC 2014 (CS6, CS5, etc) do not support Windows Ink.
+{:.alert-warning}
+
 If Photoshop CC is not detecting pressure, try the following:
 
 1. Go to `%appdata%\Adobe\Adobe Photoshop 2026\Adobe Photoshop 2026 Settings`


### PR DESCRIPTION
CS6 and before is back when adobe didnt run a subscription model so some users are still using these and it can be a bit confusing. Though we list the instructions as for Photoshop CC not CS it's worth making this more clear.