### PR TITLE
Site head: Ignore canonical link in HTML-Proofer

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -9,7 +9,7 @@
     <title>{{ site.title }}</title>
     {%- endif -%}
     {% include styles.html %}
-    <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html',''}}">
+    <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html',''}}" data-proofer-ignore>
   </head>
   <body>
     <header class="mb-4">


### PR DESCRIPTION
Otherwise this causes new pages to appear as always 404'ing when testing, as seen in failing tests in #285