### PR TITLE
Attempt to make WinUSB install notes clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The next version of OpenTabletDriver.Web
 ### Requirements
 
 - [Ruby](https://www.ruby-lang.org/en/downloads/) (tested with Ruby 3.4)
+- Ruby Bundler. This may come preinstalled or require an additional package. Run `bundle --version` to check if you have it installed.
+    - On Linux from your package manager: look for a `ruby-bundler`, `ruby-default-gems`, or similar package.
+    - As a gem: `gem install bundler` (note that it may not be on PATH by default).
 
 ## Steps
 

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -18,6 +18,7 @@ group :jekyll_plugins do
 end
 
 gem 'json'
+gem 'erb'
 gem "bootswatch", github: "thomaspark/bootswatch", tag: "v5.3.8"
 gem "bootstrap", "~> 5.3.8"
 

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    erb (6.0.7)
     eventmachine (1.2.7)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
@@ -161,6 +162,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap (~> 5.3.8)
   bootswatch!
+  erb
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.3)
   json

--- a/site/_wiki/Install/Windows.md
+++ b/site/_wiki/Install/Windows.md
@@ -29,11 +29,13 @@ Alternatively you can install it to a new directory.
 
     > You can create a shortcut to this file, just make sure that the working directory points to the extracted directory.
 
-## Installation of WinUSB {#winusb}
+### (Usually not required) Installation of WinUSB {#winusb}
 
 Some tablets require Zadig's WinUSB installed on a device interface to interact with the tablet
 correctly. To figure out if your tablet requires WinUSB, carefully check the notes on
 [the supported list of tablets here]({% link _sections/Tablets.md %}).
+This is a list of ALL tablets supported by OpenTabletDriver, NOT a list of all tablets that need WinUSB.
+If your tablet does not have a note specifically mentioning `Zadig’s WinUSB`, you DO NOT need WinUSB.
 
 Some WinUSB-requiring tablets require a specific interface to be chosen.
 This is also noted in the list of tablets, if relevant.


### PR DESCRIPTION
I finally waded through the dependency jungle and succeeded in getting this thing running to test my changes... `bundler` does not come installed by default. The `erb` gem was removed at some point or something like that so we need to add it explicitly. At least this is what I needed to get it working on Arch.

- WinUSB installation is now a substep.
- The supported tablets list is explained to not be a list of tablets that needs WinUSB but rather a list of tablets that OTD supports. There's been at least two people now who have come to support channels confused about this specifically.
- Added `(Usually not required)` to the step name

If all of this doesnt make people turn their brains on for a second, I think it's a lost cause.

<img width="1413" height="781" alt="image" src="https://github.com/user-attachments/assets/244494ee-b7b7-4245-a364-afadab598d5a" />
