### PR TITLE
Add plugin creator metadata

### DIFF
--- a/site/_layouts/plugins.html
+++ b/site/_layouts/plugins.html
@@ -80,8 +80,8 @@ layout: default
             </div>
             <!-- plugin name -->
             <span class="h4" style="margin-bottom: 0px; display: block;">{{ metadata.Name }}</span>
-            <!-- plugin author -->
-            <span class="small" style="margin-top: -2px; display: block">by {{ metadata.Owner }}</span>
+            <!-- plugin author/maintainer and creator -->
+            <span class="small" style="margin-top: -2px; display: block">by {{ metadata.Owner }}{% if metadata.Creator != nil %} and {{ metadata.Creator }}{% endif %}</span>
             <!-- plugin body -->
             <div class="my-2">
               {{ metadata.Description }}


### PR DESCRIPTION
<img width="456" height="171" alt="image" src="https://github.com/user-attachments/assets/d32ea96b-2c40-4124-addd-af184a95277a" />

Might need to be changed in the future if we end up with plugins that have multiple people listed in the creators (wouldnt want it to say something like `X and Y and Z` instead of `X, Y, and Z`) but for now this should be fine.