### PR TITLE
FAQ/General: Add 'GUI manages daemon if daemon not started' section

### DIFF
--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -136,7 +136,7 @@ That means if you start the daemon before starting the GUI, then the GUI no
 longer manages the daemon process, and you can open and close the GUI
 separately as needed.
 
-> **Note:** The Linux version of the OpenTabletDriver GUI does _not_ manage the
+> **Note:** The Linux version of the OpenTabletDriver GUI does *not* manage the
   daemon for you, yet.
 >
 > For more details, see OpenTabletDriver issue

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -122,6 +122,20 @@ This is a bug that is planned to be fixed.
 You can see the progress on GitHub here:
 [OpenTabletDriver#1143](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/1143)
 
+## Why does my tablet stop responding when I close the OpenTabletDriver user interface? {#gui-is-almost-always-the-driver}
+
+Compared to most other device drivers, OpenTabletDriver is a user-mode driver,
+which means it needs to run an active application to be able to process data
+from your tablet.
+
+OpenTabletDriver is split into 2 parts: the daemon and the GUI. If you launch
+the GUI without the daemon running, the GUI starts an internal daemon process
+and manages the daemon for you.
+
+That means if you start the daemon before starting the GUI, then the GUI no
+longer manages the daemon process, and you can open and close the GUI
+separately as needed.
+
 ## How to convert areas to and from OpenTabletDriver? {#area-conversion}
 
 ### Conversion through the OpenTabletDriver UI

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -122,7 +122,7 @@ This is a bug that is planned to be fixed.
 You can see the progress on GitHub here:
 [OpenTabletDriver#1143](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/1143)
 
-## Why does my tablet stop responding when I close the OpenTabletDriver user interface? {#gui-is-almost-always-the-driver}
+## My tablet stop responding when I close the OpenTabletDriver user interface {#gui-is-almost-always-the-driver}
 
 Compared to most other device drivers, OpenTabletDriver is a user-mode driver,
 which means it needs to run an active application to be able to process data

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -136,6 +136,13 @@ That means if you start the daemon before starting the GUI, then the GUI no
 longer manages the daemon process, and you can open and close the GUI
 separately as needed.
 
+> **Note:** The Linux version of the OpenTabletDriver GUI does _not_ manage the
+  daemon for you, yet.
+>
+> For more details, see OpenTabletDriver issue
+  [#4529](https://github.com/OpenTabletDriver/OpenTabletDriver/issues/4529).
+{:.alert-primary}
+
 ## How to convert areas to and from OpenTabletDriver? {#area-conversion}
 
 ### Conversion through the OpenTabletDriver UI


### PR DESCRIPTION
Fixes #329

As mentioned in the linked issue, a small handful of users gets confused over the fact that the driver stops when the GUI is closed.

I've added some text that explains why this is the case, and briefly how to work around it.