### PR TITLE
Wiki: Add how to override tablet configurations

### DIFF
--- a/site/_wiki/Documentation/ConfigurationGuide.md
+++ b/site/_wiki/Documentation/ConfigurationGuide.md
@@ -14,6 +14,32 @@ on that page.
 
 [Tablet configuration reference]: {% link _wiki/Development/Configurations.md %}
 
+### Adding custom tablet configurations {#installing-overrides}
+
+To test your new tablet configuration (internally named 'overrides'), you do
+not need to recompile OpenTabletDriver from source.
+
+Instead, you can place them in the designated `Configurations` folder as
+described in [the AppData section of the General FAQ](/Wiki/FAQ/General#appdata).
+
+If successful, you should see a log message similar to this:
+
+| Log Level | Log Group | Log Message |
+| :-------: | :-------: | :---------- |
+| Info      | Detect    | 1 configurations exist in '`<your configurations path>`'. Built-in configurations may be overridden if the Name matches exactly.
+
+Additionally, if you are overriding an existing configuration (by matching the
+`Name` key value of the internal configuration exactly), you should also see
+the following message during the detection loop:
+
+| Log Level | Log Group | Log Message |
+| :-------: | :-------: | :---------- |
+| Debug     | Detect    | Searching for tablet '`<tablet name>`'
+| Info      | Detect    | Overriding tablet configuration '`<tablet name>`'
+
+> **Note:** OpenTabletDriver versions before v0.6.7 has limited logging for
+> configuration overrides
+
 ## Preparing your system for adding support
 
 It is highly recommended to remove (or unload) your existing tablet drivers

--- a/site/_wiki/Documentation/ConfigurationGuide.md
+++ b/site/_wiki/Documentation/ConfigurationGuide.md
@@ -37,7 +37,7 @@ the following message during the detection loop:
 | Debug     | Detect    | Searching for tablet '`<tablet name>`'
 | Info      | Detect    | Overriding tablet configuration '`<tablet name>`'
 
-> **Note:** OpenTabletDriver versions before v0.6.7 has limited logging for
+> **Note:** OpenTabletDriver versions before v0.6.7 have limited logging for
 > configuration overrides
 
 ## Preparing your system for adding support

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -46,7 +46,7 @@ The application data directory contents are as follows:
 |       Cache       | Folder | Contains cached metadata for the Plugin Manager
 |      Plugins      | Folder | Contains installed plugins (`.dll` files). This folder should not be modified manually.
 |      Presets      | Folder | Contains saved presets
-|   Configurations  | Folder | (optional) Contains user-defined tablet configuration overrides (or additions)
+|   Configurations  | Folder | (optional) Contains user-defined tablet configuration overrides or additions
 {: .table .table-dark }
 
 > **Linux users:** Tablet configuration overrides can also be placed in `~/.local/share/OpenTabletDriver/Configurations/`

--- a/site/_wiki/FAQ/General.md
+++ b/site/_wiki/FAQ/General.md
@@ -46,7 +46,10 @@ The application data directory contents are as follows:
 |       Cache       | Folder | Contains cached metadata for the Plugin Manager
 |      Plugins      | Folder | Contains installed plugins (`.dll` files). This folder should not be modified manually.
 |      Presets      | Folder | Contains saved presets
+|   Configurations  | Folder | (optional) Contains user-defined tablet configuration overrides (or additions)
 {: .table .table-dark }
+
+> **Linux users:** Tablet configuration overrides can also be placed in `~/.local/share/OpenTabletDriver/Configurations/`
 
 ## My cursor is going crazy! It teleports everywhere! {#emi-interference}
 


### PR DESCRIPTION
Fixes #282

- Added `Configurations` folder to `AppData` section
- Added a bit about how config overrides work to the tablet config guide