### PR TITLE
Plugins: Always add latest OTD version

### DIFF
--- a/site/_layouts/plugins.html
+++ b/site/_layouts/plugins.html
@@ -26,7 +26,8 @@ layout: default
             {%- endfor -%}
           {%- endfor -%}
 
-          {% assign otdversions = otdversions | sort | uniq | reverse %}
+          {%- assign latestotdversion = site.data.otd-versions | last -%}
+          {%- assign otdversions = otdversions | push: latestotdversion | sort | uniq | reverse -%}
 
           <option value="">All Versions</option>
           {% assign elementAttributes = " selected" %}


### PR DESCRIPTION
As described in #235, the plugin version list is populated by existing plugin metadata. This means that when a new OpenTabletDriver version is released, the list does not contain the version until a plugin with an appropriate `SupportedDriverVersion` appears.

This PR changes that and always adds the latest OpenTabletDriver version as defined in the `otd-versions` data array. The list is already sorted and pruned for duplicates, so this change should be fairly safe. I manually checked the "latest version retrieval" variable (`latestotdversion` in the changes) and it indeed currently points to `v0.6.7` so this change should be correct.

fixes #235