### PR TITLE
Unify OpenTabletDriver .NET version to single reference

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,4 +29,3 @@ jobs:
         with:
           files: .
           dot: true
-          ignore_files: site/_includes/ # needs special treatment, ignore for now

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+site/_includes/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,5 @@
+# FIXME: Issue #126, markdowncli checks markdown before Liquid tags are rendered
+#        https://github.com/OpenTabletDriver/opentabletdriver.github.io/issues/126
+#        This file shouldn't be necessary once the above issue is solved
 site/_includes/
+site/_sections/Framework.md

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -23,6 +23,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   OpenTabletDriver is an open source, cross-platform, low latency, user-mode tablet driver.
 baseurl: "" # webserver path, blank for GitHub pages
 url: https://opentabletdriver.net # full URI to website
+# the .NET runtime version used by OpenTabletDriver. Used for user-facing content and download links
+otd_dotnet_version: 8.0
 
 sass:
   sass_dir: _sass

--- a/site/_sections/Framework.md
+++ b/site/_sections/Framework.md
@@ -2,24 +2,24 @@
 title: Frameworks
 ---
 
-# .NET Desktop Runtime
+## .NET Desktop Runtime
 
 OpenTabletDriver currently uses .NET {{ site.otd_dotnet_version }}.
 
-## Windows
+### Windows
 
 [x64](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/windowsdesktop-runtime-win-x64.exe)
 
-## MacOS
+### MacOS
 
 [arm64](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/dotnet-runtime-osx-arm64.pkg)
 
 [x86-64/x64 (Intel based)](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/dotnet-runtime-osx-x64.pkg)
 
-## Linux
+### Linux
 
 See the [official Linux installation documentation](https://docs.microsoft.com/en-us/dotnet/core/install/linux).
 
-## Uncommon builds
+### Uncommon builds
 
 [Windows arm64](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/windowsdesktop-runtime-win-arm64.exe)

--- a/site/_sections/Framework.md
+++ b/site/_sections/Framework.md
@@ -2,15 +2,19 @@
 title: Frameworks
 ---
 
+# .NET Desktop Runtime
+
+OpenTabletDriver currently uses .NET {{ site.otd_dotnet_version }}.
+
 ## Windows
 
-[x64](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
+[x64](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/windowsdesktop-runtime-win-x64.exe)
 
 ## MacOS
 
-[arm64](https://aka.ms/dotnet/8.0/dotnet-runtime-osx-arm64.pkg)
+[arm64](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/dotnet-runtime-osx-arm64.pkg)
 
-[x86-64/x64 (Intel based)](https://aka.ms/dotnet/8.0/dotnet-runtime-osx-x64.pkg)
+[x86-64/x64 (Intel based)](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/dotnet-runtime-osx-x64.pkg)
 
 ## Linux
 
@@ -18,4 +22,4 @@ See the [official Linux installation documentation](https://docs.microsoft.com/e
 
 ## Uncommon builds
 
-[Windows arm64](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-arm64.exe)
+[Windows arm64](https://aka.ms/dotnet/{{ site.otd_dotnet_version }}/windowsdesktop-runtime-win-arm64.exe)

--- a/site/_wiki/Install/Windows.md
+++ b/site/_wiki/Install/Windows.md
@@ -5,7 +5,7 @@ hide_from_auto_list: true
 
 ## Dependencies {#dependencies}
 
-1. Install the [.NET 8 Desktop Runtime x64]({% link _sections/Framework.md %})
+1. Install the [.NET {{ site.otd_dotnet_version }} Desktop Runtime x64]({% link _sections/Framework.md %})
 
 If you were previously using the standalone installer/updater (before v0.6), switch to the new
 method for installing OpenTabletDriver below.


### PR DESCRIPTION
Simplifies maintenance when upstream .NET versions inevitably change

Helps with #371

I might have missed a reference or 2 so any reviewers please check for this if possible.